### PR TITLE
fix: screenshot tool is not read-only (raises/focuses window)

### DIFF
--- a/scripts/mcp_safety_check.py
+++ b/scripts/mcp_safety_check.py
@@ -86,7 +86,6 @@ READ_ONLY_TOOLS = {
     "get_app_state",
     "list_windows",
     "focused_window",
-    "screenshot",
 }
 
 DESTRUCTIVE_MUTATING_TOOLS = {
@@ -110,7 +109,6 @@ OPEN_WORLD_TOOLS = EXPECTED_TOOLS - {
     "doctor",
     "setup_accessibility",
     "setup_window_targeting",
-    "screenshot",
 }
 
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -314,10 +314,10 @@ impl ComputerUseLinux {
         name = "screenshot",
         description = "Capture the screen and return it as a viewable image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped to just that window, so you see the app on its own rather than the whole desktop. Returns the PNG image plus a short caption (dimensions, source, and crop bounds).",
         annotations(
-            read_only_hint = true,
+            read_only_hint = false,
             destructive_hint = false,
-            idempotent_hint = true,
-            open_world_hint = false
+            idempotent_hint = false,
+            open_world_hint = true
         )
     )]
     async fn screenshot(


### PR DESCRIPTION
The `screenshot` tool raises the target window to the front before capturing — a desktop focus side effect — so the read-only/idempotent annotations were wrong.

`read_only_hint` true→false, `idempotent_hint` true→false, `open_world_hint` false→true.

Mirrors the codex-desktop-linux fix (27d2543, by @ilysenko); keeps the two crates in sync at 0.2.3. No version bump (0.2.3 not yet released).