### PR TITLE
Cross-reference the sibling agent-workspace-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ If you're running this on a shared workstation, set `ydotoold`'s socket permissi
 
 If `doctor` is green and a specific tool still misbehaves, file an issue with the JSON output of `doctor` and the failing tool's request payload.
 
+## Related
+
+- [agent-workspace-linux](https://github.com/agent-sh/agent-workspace-linux) — the sibling MCP that gives an agent its **own** isolated Linux desktop (a hidden Xvfb display with its own apps and browser) instead of driving yours. It is the inverse of this project: `computer-use-linux` automates the desktop you are already on; `agent-workspace-linux` sandboxes the agent in a separate one. Use them together.
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the local development workflow, CI gates, and PR expectations. Report security vulnerabilities through [SECURITY.md](SECURITY.md), not public issues.


### PR DESCRIPTION
Reciprocal of agent-sh/agent-workspace-linux#7 — links the two complementary MCPs (drive the real desktop vs. an isolated agent-owned one). README-only.