### PR TITLE
ci(security): pin softprops/action-gh-release to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
             sha256sum ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
             sha256sum computer-use-linux-cosmic-${{ matrix.target }} > computer-use-linux-cosmic-${{ matrix.target }}.sha256
           )
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             dist/${{ matrix.asset }}


### PR DESCRIPTION
Resolves CodeQL `actions/unpinned-tag`: pins `softprops/action-gh-release@v2` to commit SHA `3bb1273` (version in trailing comment). YAML validated.