### PR TITLE
fix: read GTK4 a11y trees by pinning proxy destination (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- GTK4 applications (Nautilus, Text Editor, baobab, and others) now return their
+  full accessibility tree instead of a single `role: "unknown"` root with
+  `child_count: 0`. Reads were routed through the `atspi` `P2P` trait's
+  `object_as_accessible`, whose no-peer fallback builds a proxy with a path but
+  no destination; on the shared a11y bus that fails with `ServiceUnknown` for
+  any app that does not advertise a peer-to-peer bus address. Modern GTK4 apps
+  do not implement the legacy `GetApplicationBusAddress`, so they hit the broken
+  fallback while GTK3/Chromium/Electron apps kept working. Reads now use
+  `ObjectRefExt::as_accessible_proxy`, which always pins the destination to the
+  object's bus name. (#31)
+
 ## [0.2.8] - 2026-06-17
 
 ### Changed

--- a/src/atspi_tree.rs
+++ b/src/atspi_tree.rs
@@ -1,8 +1,10 @@
 use crate::diagnostics::hydrate_session_bus_env;
 use anyhow::{anyhow, Context, Result};
 use atspi::{
-    connection::P2P,
-    proxy::{accessible::AccessibleProxy, proxy_ext::ProxyExt},
+    proxy::{
+        accessible::{AccessibleProxy, ObjectRefExt},
+        proxy_ext::ProxyExt,
+    },
     AccessibilityConnection, CoordType, ObjectRef, ObjectRefOwned, StateSet,
 };
 use schemars::JsonSchema;
@@ -105,7 +107,7 @@ pub async fn list_accessible_apps(limit: usize) -> Result<Vec<AccessibleAppSumma
     let mut apps = Vec::new();
 
     for object_ref in roots.into_iter().take(limit) {
-        if let Ok(proxy) = conn.object_as_accessible(&object_ref).await {
+        if let Ok(proxy) = open_accessible(&conn, &object_ref).await {
             apps.push(read_app_summary(&proxy, &object_ref, dbus.as_ref()).await);
         }
     }
@@ -135,7 +137,7 @@ pub async fn snapshot_tree(
             break;
         }
 
-        let Ok(proxy) = conn.object_as_accessible(&object_ref).await else {
+        let Ok(proxy) = open_accessible(&conn, &object_ref).await else {
             continue;
         };
         let index = nodes.len() as u32;
@@ -161,8 +163,7 @@ pub async fn perform_action(
 ) -> Result<ActionInvocation> {
     let conn = connect().await?;
     let object_ref = object_ref_from_id(object_ref_id)?;
-    let proxy = conn
-        .object_as_accessible(&object_ref)
+    let proxy = open_accessible(&conn, &object_ref)
         .await
         .with_context(|| format!("failed to open AT-SPI object {object_ref_id}"))?;
     let action = proxy
@@ -191,8 +192,7 @@ pub async fn perform_action(
 pub async fn set_element_value(object_ref_id: &str, value: &str) -> Result<ValueSetInvocation> {
     let conn = connect().await?;
     let object_ref = object_ref_from_id(object_ref_id)?;
-    let proxy = conn
-        .object_as_accessible(&object_ref)
+    let proxy = open_accessible(&conn, &object_ref)
         .await
         .with_context(|| format!("failed to open AT-SPI object {object_ref_id}"))?;
     let proxies = proxy.proxies().await?;
@@ -238,6 +238,25 @@ async fn connect() -> Result<AccessibilityConnection> {
     AccessibilityConnection::new()
         .await
         .context("failed to connect to AT-SPI bus")
+}
+
+/// Open an `AccessibleProxy` for an object on the a11y bus.
+///
+/// We deliberately avoid `AccessibilityConnection::object_as_accessible` (the
+/// `P2P` trait). For apps that advertise a peer-to-peer bus address it routes
+/// reads over that socket, but for apps that don't (notably GTK4 apps such as
+/// Nautilus / Text Editor / baobab, which don't implement the legacy
+/// `GetApplicationBusAddress`) it falls back to a proxy built with only a path
+/// and *no destination*. On the shared a11y bus that proxy can't address the
+/// app and every call fails with `ServiceUnknown`, which surfaces as an empty
+/// tree (`role: "unknown"`, `child_count: 0`). `as_accessible_proxy` always
+/// pins the destination to the object's bus name, so it works for every app
+/// regardless of P2P support. See issue #31.
+async fn open_accessible<'r>(
+    conn: &AccessibilityConnection,
+    object_ref: &'r ObjectRefOwned,
+) -> Result<AccessibleProxy<'r>, atspi::AtspiError> {
+    object_ref.as_accessible_proxy(conn.connection()).await
 }
 
 async fn registry_children(conn: &AccessibilityConnection) -> Result<Vec<ObjectRefOwned>> {
@@ -313,7 +332,7 @@ async fn root_matches(
     object_ref: &ObjectRefOwned,
     needle: &str,
 ) -> bool {
-    let Ok(proxy) = conn.object_as_accessible(object_ref).await else {
+    let Ok(proxy) = open_accessible(conn, object_ref).await else {
         return object_ref_id(object_ref)
             .to_ascii_lowercase()
             .contains(needle);
@@ -325,7 +344,7 @@ async fn root_matches(
 
     let children = proxy.get_children().await.unwrap_or_default();
     for child_ref in children.into_iter().take(8) {
-        let Ok(child_proxy) = conn.object_as_accessible(&child_ref).await else {
+        let Ok(child_proxy) = open_accessible(conn, &child_ref).await else {
             continue;
         };
         if proxy_matches(&child_proxy, &child_ref, needle).await {


### PR DESCRIPTION
Fixes #31.

## What was happening

`get_app_state` / `list_apps` returned an empty tree for GTK4 apps - a single root with `role: "unknown"`, `child_count: 0` - while GTK3 / Chromium / Electron worked.

## Root cause (not what the issue guessed)

The issue suspected the `atspi` crate couldn't parse GTK4's app-specific object paths (`/org/gnome/<App>/a11y/<uuid>`). That's not it - the crate deserializes those paths fine.

The reads went through the `atspi` `P2P` trait's `object_as_accessible`. When an app advertises a peer-to-peer bus address, reads route over that socket. When it doesn't, the fallback builds an `AccessibleProxy` with a path but **no destination**. On the shared a11y bus that proxy can't address the app, so every call fails with `ServiceUnknown` - which `read_node` swallows into `role: "unknown"` / `child_count: 0`.

The working/broken split tracks **P2P support, not the toolkit**. Probed live on GNOME 50:

| app | toolkit | advertises P2P | old result |
|---|---|---|---|
| gnome-disks | GTK3 | yes | full tree |
| Electron / Chrome | - | yes | full tree |
| Nautilus | GTK4 | no | empty (`unknown`/0) |
| ptyxis / mutter-x11-frames | - | no | empty (`unknown`/0) |

GTK4 apps just don't implement the legacy `GetApplicationBusAddress`, so they always hit the broken fallback.

## Fix

Drop the `P2P` trait and open proxies with `ObjectRefExt::as_accessible_proxy`, which always pins the destination to the object's bus name. One `open_accessible` helper, all six call sites swapped.

## Verification (live, GNOME 50 Wayland, real `snapshot_tree`)

- **Nautilus (GTK4, was broken):** 1 node -> **28 nodes**, descending the `/org/gnome/Nautilus/a11y/<uuid>` paths, `application -> window "Home" -> ...`
- **gnome-disks (GTK3, control):** 111 nodes, unchanged - no regression

Local gates green: `cargo fmt --check`, `cargo check --locked --all-targets`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test` (120 passed).