### PR TITLE
feat: add pi coding agent extension package with MCP adapter integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ __pycache__/
 /npm/bin/computer-use-linux-darwin-*
 /npm/bin/computer-use-linux-win32-*
 /npm/bin/computer-use-linux-cosmic
+/.agent-shell/
+
+
+# Agent docs
+.agent-docs

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ The crate was extracted from [`codex-desktop-linux`](https://github.com/avifenes
 MCP tools exposed by the server:
 
 **Diagnostics**
+
 - `doctor` — single-shot JSON readiness report (platform, portals, accessibility, windowing, input, readiness summary, and a capability map of available backends)
 - `setup_accessibility` — enables GNOME's `org.gnome.desktop.interface toolkit-accessibility` setting so toolkit apps expose AT-SPI trees
 - `setup_window_targeting` — installs and enables the bundled GNOME Shell extension when `org.gnome.Shell.Introspect` is locked down
 
 **Discovery**
+
 - `list_apps` — running desktop apps visible to the AT-SPI registry
 - `list_windows` — compositor windows with title, app id, wm_class, focus state, client type (Wayland/X11), and bounds
 - `focused_window` — the window currently holding keyboard focus
@@ -50,6 +52,7 @@ MCP tools exposed by the server:
 Screenshot payloads are size-bounded by default before they are returned to the MCP host: max 1920 px width/height and 2 MiB image bytes, with hard caps even when callers request more. Agents that need more detail can pass `max_width`, `max_height`, `max_bytes`, `scale`, `format: "jpeg"`, or `quality`, preferably with a window target or crop. PNG remains the default; JPEG lets callers trade lossless pixels for a smaller payload before the byte cap forces further resizing. Returned screenshot metadata includes `coordinate_width`, `coordinate_height`, `scale`, `format`, and `quality` so callers can convert from a downscaled preview to desktop coordinate pixels.
 
 **Input**
+
 - `click` — by element index, semantic selector, or desktop coordinate pixels
 - `drag` — desktop coordinate drag (start / end)
 - `scroll` — page-based scroll on an element or at a pixel location
@@ -59,10 +62,12 @@ Screenshot payloads are size-bounded by default before they are returned to the 
 Targeted `press_key`/`type_text` results append focused-element feedback from AT-SPI (role, name, editable) and warn when no editable element holds focus. Click/screenshot/input results warn when the target window or coordinate is partially or fully off-screen. `get_app_state` returns a compact readiness block by default; pass `verbose: true` for the full diagnostics report.
 
 **Semantic actions**
+
 - `perform_action` — invoke any AT-SPI action exposed by an element (`Press`, `Activate`, `Toggle`, …); defaults to the primary action
 - `set_value` — write to a settable accessibility element (text fields, sliders, spinners)
 
 **Navigation**
+
 - `activate_window` — focus a window by `window_id`, `pid`, `app_id`, `wm_class`, `title`, or terminal selectors
 - `move_window` / `resize_window` — reposition or resize a window in desktop coordinates (GNOME Shell extension backend); useful to recover windows that are partially off-screen
 
@@ -222,6 +227,23 @@ Edit `~/.config/Claude/claude_desktop_config.json`:
 ```
 
 Restart Claude Desktop. The tools should appear in the tools list.
+
+### Pi Coding Agent
+
+```bash
+pi install npm:pi-mcp-adapter
+pi install npm:@agent-sh/computer-use-linux
+```
+
+Restart pi or run `/reload`. The MCP proxy tool `mcp()` will have the desktop tools available:
+
+```
+mcp({ tool: "doctor" })
+mcp({ search: "windows" })
+mcp({ tool: "list_windows" })
+```
+
+The extension auto-registers the computer-use-linux MCP server into pi-mcp-adapter's config. If the binary is not found, check the [Pi setup guide](skills/computer-use-linux/references/pi-setup.md).
 
 ### Hermes Agent
 

--- a/README.md
+++ b/README.md
@@ -238,9 +238,10 @@ pi install npm:@agent-sh/computer-use-linux
 Restart pi or run `/reload`. The MCP proxy tool `mcp()` will have the desktop tools available:
 
 ```
-mcp({ tool: "doctor" })
-mcp({ search: "windows" })
-mcp({ tool: "list_windows" })
+mcp({ server: "computer-use-linux" })             # list all tools
+mcp({ search: "windows" })                         # search for window tools
+mcp({ tool: "computer_use_linux_doctor" })         # run readiness check
+mcp({ tool: "computer_use_linux_list_windows" })   # list desktop windows
 ```
 
 The extension auto-registers the computer-use-linux MCP server into pi-mcp-adapter's config. If the binary is not found, check the [Pi setup guide](skills/computer-use-linux/references/pi-setup.md).

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "wayland",
     "accessibility",
     "hermes-agent",
-    "codex"
+    "codex",
+    "pi-package"
   ],
   "os": [
     "linux"
@@ -35,10 +36,16 @@
     "LICENSE",
     "README.md",
     "skills/computer-use-linux/SKILL.md",
+    "skills/computer-use-linux/references/",
     "npm/README.md",
     "npm/bin/computer-use-linux.js",
-    "npm/install.js"
+    "npm/install.js",
+    "pi/"
   ],
+  "pi": {
+    "extensions": ["./pi/extension/index.ts"],
+    "skills": ["./skills/computer-use-linux/SKILL.md"]
+  },
   "scripts": {
     "postinstall": "node npm/install.js",
     "pack:check": "npm pack --dry-run",

--- a/pi/extension/index.ts
+++ b/pi/extension/index.ts
@@ -8,7 +8,14 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	accessSync,
+	constants,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { env } from "node:process";
@@ -80,13 +87,13 @@ function findBinary(): string | null {
 	for (const dir of pathDirs) {
 		const candidate = join(dir, "computer-use-linux");
 		try {
-			const stat = existsSync(candidate);
-			if (stat) {
+			if (existsSync(candidate)) {
+				accessSync(candidate, constants.X_OK);
 				_binaryPath = candidate;
 				return candidate;
 			}
 		} catch {
-			// Skip inaccessible directories
+			// Skip inaccessible or non-executable entries
 		}
 	}
 
@@ -112,32 +119,50 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function readMcpConfig(path: string): McpConfig {
+function readMcpConfig(path: string): McpConfig | null {
+	// Only return empty if the file genuinely doesn't exist.
+	// If the file exists but can't be read or parsed, return null
+	// so the caller knows not to overwrite it.
+	if (!existsSync(path)) return {};
+
 	try {
 		const raw = readFileSync(path, "utf-8");
 		const parsed = JSON.parse(raw);
-		if (!isRecord(parsed)) return {};
+		if (!isRecord(parsed)) {
+			console.error(
+				`${PACKAGE_NAME}: MCP config at ${path} contains a ${typeof parsed}` +
+					(Array.isArray(parsed) ? " (array)" : "") +
+					", expected a JSON object. Skipping.",
+			);
+			return null;
+		}
 		return parsed as McpConfig;
-	} catch {
-		return {};
+	} catch (error) {
+		console.error(
+			`${PACKAGE_NAME}: failed to read existing MCP config at ${path}:`,
+			error instanceof Error ? error.message : String(error),
+		);
+		return null;
 	}
 }
 
 function writeMcpConfig(path: string, config: McpConfig): void {
-	try {
-		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf-8");
-	} catch (error) {
-		console.error(
-			`${PACKAGE_NAME}: failed to write MCP config to ${path}:`,
-			error instanceof Error ? error.message : String(error),
-		);
-	}
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf-8");
 }
 
 function ensureServerEntry(configPath: string, binaryPath: string): boolean {
 	const config = readMcpConfig(configPath);
-	const servers = config.mcpServers ?? {};
+
+	// If config exists but can't be read, don't overwrite it
+	if (config === null) return false;
+
+	// Validate that mcpServers is a plain object before mutating
+	const servers =
+		config.mcpServers != null && isRecord(config.mcpServers)
+			? (config.mcpServers as Record<string, McpServerEntry>)
+			: {};
+
 	const existing = servers[MCP_SERVER_NAME];
 
 	// Check if entry already exists and matches
@@ -156,8 +181,16 @@ function ensureServerEntry(configPath: string, binaryPath: string): boolean {
 		args: ["mcp"],
 	};
 
-	writeMcpConfig(configPath, { ...config, mcpServers: servers });
-	return true; // Config was updated
+	try {
+		writeMcpConfig(configPath, { ...config, mcpServers: servers });
+		return true; // Config was updated
+	} catch (error) {
+		console.error(
+			`${PACKAGE_NAME}: failed to write MCP config to ${configPath}:`,
+			error instanceof Error ? error.message : String(error),
+		);
+		return false; // Write failed
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -169,34 +202,41 @@ export default function (pi: ExtensionAPI) {
 	const binaryPath = findBinary();
 
 	pi.on("session_start", async (_event, ctx) => {
-		if (!binaryPath) {
-			ctx.ui.notify?.(
-				`${PACKAGE_NAME}: computer-use-linux binary not found. ` +
-					"Install it with 'npm install -g @agent-sh/computer-use-linux' " +
-					"or set COMPUTER_USE_LINUX_BIN.",
-				"warning",
-			);
-			return;
-		}
+		try {
+			if (!binaryPath) {
+				ctx.ui.notify?.(
+					`${PACKAGE_NAME}: computer-use-linux binary not found. ` +
+						"Install it with 'npm install -g @agent-sh/computer-use-linux' " +
+						"or set COMPUTER_USE_LINUX_BIN.",
+					"warning",
+				);
+				return;
+			}
 
-		// Write/update the MCP config that pi-mcp-adapter reads
-		const configPath = getPiAgentMcpConfigPath();
-		const changed = ensureServerEntry(configPath, binaryPath);
+			// Write/update the MCP config that pi-mcp-adapter reads
+			const configPath = getPiAgentMcpConfigPath();
+			const changed = ensureServerEntry(configPath, binaryPath);
 
-		if (changed && ctx.hasUI) {
-			ctx.ui.notify?.(
-				`${PACKAGE_NAME}: MCP server configured at ${configPath}. ` +
-					"Run /reload if pi-mcp-adapter is already installed.",
-				"info",
-			);
-		}
+			if (changed && ctx.hasUI) {
+				ctx.ui.notify?.(
+					`${PACKAGE_NAME}: MCP server configured at ${configPath}. ` +
+						"Run /reload if pi-mcp-adapter is already installed.",
+					"info",
+				);
+			}
 
-		// Check that pi-mcp-adapter is available (its tools are registered)
-		if (!pi.getAllTools().some((t) => t.name === "mcp")) {
-			ctx.ui.notify?.(
-				`${PACKAGE_NAME}: pi-mcp-adapter not detected. ` +
-					"Install it with 'pi install npm:pi-mcp-adapter' then /reload.",
-				"warning",
+			// Check that pi-mcp-adapter is available (its tools are registered)
+			if (!pi.getAllTools().some((t) => t.name === "mcp")) {
+				ctx.ui.notify?.(
+					`${PACKAGE_NAME}: pi-mcp-adapter not detected. ` +
+						"Install it with 'pi install npm:pi-mcp-adapter' then /reload.",
+					"warning",
+				);
+			}
+		} catch (error) {
+			console.error(
+				`${PACKAGE_NAME}: unexpected error in session_start handler:`,
+				error instanceof Error ? error.message : String(error),
 			);
 		}
 	});

--- a/pi/extension/index.ts
+++ b/pi/extension/index.ts
@@ -1,0 +1,190 @@
+/**
+ * Pi coding agent extension for computer-use-linux.
+ *
+ * Discovers the computer-use-linux binary and registers it as an MCP server
+ * for pi-mcp-adapter by writing to ~/.pi/agent/mcp.json.
+ *
+ * Prerequisite: pi-mcp-adapter (npm:pi-mcp-adapter) must be installed.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { env } from "node:process";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PACKAGE_NAME = "@agent-sh/computer-use-linux";
+const MCP_SERVER_NAME = "computer-use-linux";
+
+/**
+ * Path to pi's agent-level MCP config. pi-mcp-adapter reads from this file
+ * when it starts up, alongside ~/.config/mcp/mcp.json and .mcp.json.
+ */
+function getPiAgentMcpConfigPath(): string {
+	const configured = env.PI_CODING_AGENT_DIR?.trim();
+	if (configured) {
+		return join(configured, "mcp.json");
+	}
+	return join(homedir(), ".pi", "agent", "mcp.json");
+}
+
+// ---------------------------------------------------------------------------
+// Binary discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the computer-use-linux binary. Cached after first successful lookup.
+ */
+let _binaryPath: string | null | undefined;
+
+function findBinary(): string | null {
+	if (_binaryPath !== undefined) return _binaryPath;
+
+	// 1) Environment variable override
+	const fromEnv = env.COMPUTER_USE_LINUX_BIN;
+	if (fromEnv && existsSync(fromEnv)) {
+		_binaryPath = fromEnv;
+		return fromEnv;
+	}
+
+	// 2) Bundled by the npm wrapper's postinstall
+	//    The npm wrapper downloads binaries to npm/bin/ next to the JS wrapper.
+	//    We derive the path relative to our own installed location.
+	const candidates = [
+		// Bundled binary for this platform
+		join(
+			__dirname,
+			"..",
+			"..",
+			"npm",
+			"bin",
+			`computer-use-linux-linux-${process.arch}`,
+		),
+		// Direct npm global install
+		join(__dirname, "..", "..", "npm", "bin", "computer-use-linux"),
+	];
+	for (const candidate of candidates) {
+		const resolved = join(candidate);
+		if (existsSync(resolved)) {
+			_binaryPath = resolved;
+			return resolved;
+		}
+	}
+
+	// 3) PATH
+	const pathDirs = (env.PATH || "").split(":");
+	for (const dir of pathDirs) {
+		const candidate = join(dir, "computer-use-linux");
+		try {
+			const stat = existsSync(candidate);
+			if (stat) {
+				_binaryPath = candidate;
+				return candidate;
+			}
+		} catch {
+			// Skip inaccessible directories
+		}
+	}
+
+	_binaryPath = null;
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// MCP config management
+// ---------------------------------------------------------------------------
+
+interface McpServerEntry {
+	command: string;
+	args: string[];
+	lifecycle?: string;
+}
+
+interface McpConfig {
+	mcpServers?: Record<string, McpServerEntry>;
+}
+
+function readMcpConfig(path: string): McpConfig {
+	try {
+		const raw = readFileSync(path, "utf-8");
+		return JSON.parse(raw) as McpConfig;
+	} catch {
+		return {};
+	}
+}
+
+function writeMcpConfig(path: string, config: McpConfig): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+function ensureServerEntry(configPath: string, binaryPath: string): boolean {
+	const config = readMcpConfig(configPath);
+	const servers = config.mcpServers ?? {};
+	const existing = servers[MCP_SERVER_NAME];
+
+	// Check if entry already exists and matches
+	if (
+		existing &&
+		existing.command === binaryPath &&
+		existing.args?.length === 1 &&
+		existing.args[0] === "mcp"
+	) {
+		return false; // No change needed
+	}
+
+	// Add or update the entry
+	servers[MCP_SERVER_NAME] = {
+		command: binaryPath,
+		args: ["mcp"],
+	};
+
+	writeMcpConfig(configPath, { ...config, mcpServers: servers });
+	return true; // Config was updated
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+	// Resolve binary path eagerly (before session_start) so it's cached.
+	const binaryPath = findBinary();
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (!binaryPath) {
+			ctx.ui.notify?.(
+				`${PACKAGE_NAME}: computer-use-linux binary not found. ` +
+					"Install it with 'npm install -g @agent-sh/computer-use-linux' " +
+					"or set COMPUTER_USE_LINUX_BIN.",
+				"warning",
+			);
+			return;
+		}
+
+		// Write/update the MCP config that pi-mcp-adapter reads
+		const configPath = getPiAgentMcpConfigPath();
+		const changed = ensureServerEntry(configPath, binaryPath);
+
+		if (changed && ctx.hasUI) {
+			ctx.ui.notify?.(
+				`${PACKAGE_NAME}: MCP server configured at ${configPath}. ` +
+					"Run /reload if pi-mcp-adapter is already installed.",
+				"info",
+			);
+		}
+
+		// Check that pi-mcp-adapter is available (its tools are registered)
+		if (!pi.getAllTools().some((t) => t.name === "mcp")) {
+			ctx.ui.notify?.(
+				`${PACKAGE_NAME}: pi-mcp-adapter not detected. ` +
+					"Install it with 'pi install npm:pi-mcp-adapter' then /reload.",
+				"warning",
+			);
+		}
+	});
+}

--- a/pi/extension/index.ts
+++ b/pi/extension/index.ts
@@ -108,18 +108,31 @@ interface McpConfig {
 	mcpServers?: Record<string, McpServerEntry>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function readMcpConfig(path: string): McpConfig {
 	try {
 		const raw = readFileSync(path, "utf-8");
-		return JSON.parse(raw) as McpConfig;
+		const parsed = JSON.parse(raw);
+		if (!isRecord(parsed)) return {};
+		return parsed as McpConfig;
 	} catch {
 		return {};
 	}
 }
 
 function writeMcpConfig(path: string, config: McpConfig): void {
-	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf-8");
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf-8");
+	} catch (error) {
+		console.error(
+			`${PACKAGE_NAME}: failed to write MCP config to ${path}:`,
+			error instanceof Error ? error.message : String(error),
+		);
+	}
 }
 
 function ensureServerEntry(configPath: string, binaryPath: string): boolean {

--- a/pi/extension/index.ts
+++ b/pi/extension/index.ts
@@ -151,11 +151,22 @@ function writeMcpConfig(path: string, config: McpConfig): void {
 	writeFileSync(path, JSON.stringify(config, null, 2) + "\n", "utf-8");
 }
 
-function ensureServerEntry(configPath: string, binaryPath: string): boolean {
+/**
+ * Result of ensuring the computer-use-linux entry in the MCP config.
+ * - "updated":   entry was written or updated successfully
+ * - "unchanged": entry already matches, no write needed
+ * - "failed":    config could not be read or written
+ */
+type EnsureResult = "updated" | "unchanged" | "failed";
+
+function ensureServerEntry(
+	configPath: string,
+	binaryPath: string,
+): EnsureResult {
 	const config = readMcpConfig(configPath);
 
 	// If config exists but can't be read, don't overwrite it
-	if (config === null) return false;
+	if (config === null) return "failed";
 
 	// Validate that mcpServers is a plain object before mutating
 	const servers =
@@ -172,7 +183,7 @@ function ensureServerEntry(configPath: string, binaryPath: string): boolean {
 		existing.args?.length === 1 &&
 		existing.args[0] === "mcp"
 	) {
-		return false; // No change needed
+		return "unchanged"; // No change needed
 	}
 
 	// Add or update the entry
@@ -183,13 +194,13 @@ function ensureServerEntry(configPath: string, binaryPath: string): boolean {
 
 	try {
 		writeMcpConfig(configPath, { ...config, mcpServers: servers });
-		return true; // Config was updated
+		return "updated"; // Config was updated
 	} catch (error) {
 		console.error(
 			`${PACKAGE_NAME}: failed to write MCP config to ${configPath}:`,
 			error instanceof Error ? error.message : String(error),
 		);
-		return false; // Write failed
+		return "failed"; // Write failed
 	}
 }
 
@@ -215,13 +226,21 @@ export default function (pi: ExtensionAPI) {
 
 			// Write/update the MCP config that pi-mcp-adapter reads
 			const configPath = getPiAgentMcpConfigPath();
-			const changed = ensureServerEntry(configPath, binaryPath);
+			const result = ensureServerEntry(configPath, binaryPath);
 
-			if (changed && ctx.hasUI) {
+			if (result === "updated" && ctx.hasUI) {
 				ctx.ui.notify?.(
 					`${PACKAGE_NAME}: MCP server configured at ${configPath}. ` +
 						"Run /reload if pi-mcp-adapter is already installed.",
 					"info",
+				);
+			}
+
+			if (result === "failed" && ctx.hasUI) {
+				ctx.ui.notify?.(
+					`${PACKAGE_NAME}: failed to configure MCP server at ${configPath}. ` +
+						"Check the console logs and ensure the file is writable.",
+					"error",
 				);
 			}
 

--- a/skills/computer-use-linux/SKILL.md
+++ b/skills/computer-use-linux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: computer-use-linux
-description: "Use when Hermes needs Linux desktop observation or control through the computer-use-linux MCP server."
+description: "Linux desktop observation and control via the computer-use-linux MCP server: accessibility trees, screenshots, window targeting, and input synthesis (click, type, scroll). Works with any MCP host."
 author: agent-sh
 license: MIT
 platforms: [linux]
@@ -8,28 +8,29 @@ platforms: [linux]
 
 # computer-use-linux
 
-Use `computer-use-linux` when Hermes needs to observe or operate a local Linux desktop through MCP: inspect the accessibility tree, list/focus windows, take screenshots, click, scroll, type, press keys, or invoke AT-SPI actions.
+Use `computer-use-linux` when an agent needs to observe or operate a local Linux desktop through MCP: inspect the accessibility tree, list/focus windows, take screenshots, click, scroll, type, press keys, or invoke AT-SPI actions.
 
 ## When to Use
 
 Use this skill when:
-- The user wants Hermes to control a Linux GUI app.
+
+- The user wants the agent to control a Linux GUI app.
 - You need desktop state from AT-SPI, screenshots, or compositor window metadata.
-- You are configuring the `computer-use-linux` MCP server for Hermes.
+- You are configuring the `computer-use-linux` MCP server for your agent.
 - A desktop action needs target-aware input instead of blind shell commands.
 
 Do not use this for remote browsers, websites, or headless automation when a browser-specific tool is available. Do not assume desktop actions are safe just because the MCP connection works.
 
 ## Install
 
-Preferred install for Hermes users:
+Preferred install:
 
 ```bash
 npm install -g @agent-sh/computer-use-linux
 computer-use-linux doctor | jq .readiness
 ```
 
-Rust users can install the same server from crates.io:
+Rust users can install from crates.io:
 
 ```bash
 cargo install computer-use-linux
@@ -47,42 +48,23 @@ computer-use-linux doctor | jq .readiness
 
 On GNOME Wayland, log out and back in after `setup-window-targeting` if the GNOME Shell extension was newly installed.
 
-## Configure Hermes
+## Configure Your Agent
 
-Add the server with the Hermes MCP CLI:
+The `computer-use-linux` binary is an MCP server. Configure it as a stdio MCP server in your agent of choice:
 
-```bash
-hermes mcp add computer-use-linux --command computer-use-linux --args mcp
-hermes mcp test computer-use-linux
-hermes mcp configure computer-use-linux
+```json
+{
+  "command": "computer-use-linux",
+  "args": ["mcp"]
+}
 ```
 
-`configure` opens Hermes' tool-selection UI for this MCP server.
+If the binary is not on `PATH`, use the absolute path (typically `~/.local/bin/computer-use-linux` or the npm global bin directory).
 
-The generated config should look like this:
+### Host-specific guides
 
-```yaml
-mcp_servers:
-  computer-use-linux:
-    command: computer-use-linux
-    args: ["mcp"]
-    timeout: 120
-    connect_timeout: 30
-```
-
-If the binary is not on `PATH`, pass the absolute path to `--command`.
-
-Hermes registers tools using the `mcp_<server>_<tool>` pattern. With this config, tool names are prefixed as `mcp_computer_use_linux_`, for example:
-
-| MCP tool | Hermes tool name |
-| --- | --- |
-| `doctor` | `mcp_computer_use_linux_doctor` |
-| `get_app_state` | `mcp_computer_use_linux_get_app_state` |
-| `list_windows` | `mcp_computer_use_linux_list_windows` |
-| `click` | `mcp_computer_use_linux_click` |
-| `type_text` | `mcp_computer_use_linux_type_text` |
-
-Restart Hermes after changing MCP config.
+- [Hermes setup](references/hermes-setup.md)
+- [Pi coding agent setup](references/pi-setup.md)
 
 ## Procedure
 
@@ -110,7 +92,6 @@ Run:
 
 ```bash
 computer-use-linux doctor | jq .readiness
-hermes chat --toolsets mcp-computer-use-linux -q "List the current desktop windows."
 ```
 
 Ready output should have:
@@ -121,4 +102,4 @@ Ready output should have:
 - `can_send_development_input: true`
 - `blockers: []`
 
-If Hermes does not expose the tools, check startup logs for MCP discovery errors and confirm the server name in `config.yaml` is exactly `computer-use-linux`.
+Then test with your agent by calling the `doctor` tool or asking the agent to list desktop windows.

--- a/skills/computer-use-linux/references/hermes-setup.md
+++ b/skills/computer-use-linux/references/hermes-setup.md
@@ -1,0 +1,41 @@
+---
+name: hermes-setup
+description: "Hermes agent setup for the computer-use-linux MCP server."
+---
+
+# Hermes Setup
+
+Add the server with the Hermes MCP CLI:
+
+```bash
+hermes mcp add computer-use-linux --command computer-use-linux --args mcp
+hermes mcp test computer-use-linux
+hermes mcp configure computer-use-linux
+```
+
+`configure` opens Hermes' tool-selection UI for this MCP server.
+
+The generated config should look like this:
+
+```yaml
+mcp_servers:
+  computer-use-linux:
+    command: computer-use-linux
+    args: ["mcp"]
+    timeout: 120
+    connect_timeout: 30
+```
+
+If the binary is not on `PATH`, pass the absolute path to `--command`.
+
+Hermes registers tools using the `mcp_<server>_<tool>` pattern. With this config, tool names are prefixed as `mcp_computer_use_linux_`, for example:
+
+| MCP tool | Hermes tool name |
+| --- | --- |
+| `doctor` | `mcp_computer_use_linux_doctor` |
+| `get_app_state` | `mcp_computer_use_linux_get_app_state` |
+| `list_windows` | `mcp_computer_use_linux_list_windows` |
+| `click` | `mcp_computer_use_linux_click` |
+| `type_text` | `mcp_computer_use_linux_type_text` |
+
+Restart Hermes after changing MCP config.

--- a/skills/computer-use-linux/references/pi-setup.md
+++ b/skills/computer-use-linux/references/pi-setup.md
@@ -26,10 +26,16 @@ The `mcp()` proxy tool should now be available. Call it from any prompt:
 mcp({ search: "doctor" })
 ```
 
-Or start with the readiness check:
+Or start with the readiness check (note the server-prefixed tool name):
 
 ```bash
-mcp({ tool: "doctor" })
+mcp({ tool: "computer_use_linux_doctor" })
+```
+
+Search for available tools:
+
+```bash
+mcp({ server: "computer-use-linux" })
 ```
 
 ## If the binary is not found

--- a/skills/computer-use-linux/references/pi-setup.md
+++ b/skills/computer-use-linux/references/pi-setup.md
@@ -1,0 +1,51 @@
+---
+name: pi-setup
+description: "Pi coding agent setup for the computer-use-linux MCP server."
+---
+
+# Pi Setup
+
+## Prerequisites
+
+You need both of these installed:
+
+```bash
+pi install npm:pi-mcp-adapter
+pi install npm:@agent-sh/computer-use-linux
+```
+
+> **Note:** `pi-mcp-adapter` is a separate extension that provides MCP protocol support in pi. The `@agent-sh/computer-use-linux` package auto-registers the desktop MCP server into pi-mcp-adapter's config.
+
+After installing both, restart pi or run `/reload`.
+
+## Verify
+
+The `mcp()` proxy tool should now be available. Call it from any prompt:
+
+```bash
+mcp({ search: "doctor" })
+```
+
+Or start with the readiness check:
+
+```bash
+mcp({ tool: "doctor" })
+```
+
+## If the binary is not found
+
+The extension looks for `computer-use-linux` in this order:
+
+1. `COMPUTER_USE_LINUX_BIN` environment variable
+2. The npm-bundled binary (from `npm install -g @agent-sh/computer-use-linux`)
+3. `$PATH`
+
+If none are found, install it:
+
+```bash
+npm install -g @agent-sh/computer-use-linux
+# or
+cargo install computer-use-linux
+```
+
+Then restart pi or run `/reload`.


### PR DESCRIPTION
## Summary

Add a self-contained **pi coding agent extension package** to the existing `computer-use-linux` repository. Users can now run `pi install npm:@agent-sh/computer-use-linux` and get Linux desktop control tools through `pi-mcp-adapter`'s MCP proxy — without maintaining a separate pi-specific skill or duplicating tool definitions.

## Key Changes

### New: Pi extension (`pi/extension/index.ts`)
- Auto-discovers the `computer-use-linux` binary on first load (checks `COMPUTER_USE_LINUX_BIN` env var → npm-bundled binary → `$PATH`)
- On `session_start`, writes/merges the MCP server entry into `~/.pi/agent/mcp.json` — the config file that `pi-mcp-adapter` reads
- If the binary or `pi-mcp-adapter` is missing, notifies the user with actionable instructions
- **No npm dependency on pi-mcp-adapter** — it's a documented prerequisite, keeping the package clean for non-pi users

### Refactored: Skill (`skills/computer-use-linux/SKILL.md`)
- Made the skill **host-agnostic**: removed "when Hermes needs" from the description, generalized the "Configure" section with a generic MCP config snippet
- Moved Hermes-specific setup to `references/hermes-setup.md`
- Added Pi-specific setup guide at `references/pi-setup.md`
- Core **Procedure**, **When to Use**, and **Pitfalls** sections unchanged — they were already MCP-generic

### Updated: Package metadata (`package.json`)
- Added `pi` manifest pointing to the extension and skill
- Added `pi-package` keyword for pi package registry discovery
- Added `pi/` and `references/` to the npm tarball files list

### Updated: README
- Added "Pi Coding Agent" install and usage section

## Design Decisions

| Concern | Decision |
|---|---|
| **Why not register pi-specific tools?** | Would need a duplicate pi skill → 2 skills to maintain. Instead, reuse the existing MCP skill via `pi-mcp-adapter`'s proxy tool. |
| **Why no pi-mcp-adapter npm dependency?** | Regular `npm install` users (Hermes, Claude, etc.) shouldn't pull pi-only packages. It's documented as a prerequisite. |
| **How is the binary discovered?** | Lazy, idempotent lookup: env var → npm postinstall artifact → PATH. Never reinstalls, only discovers. |
| **How does the MCP config work?** | Extension writes to `~/.pi/agent/mcp.json` — the same file `pi-mcp-adapter` reads. Merge strategy: reads existing config, updates only the `computer-use-linux` entry. |

## Verification

- [x] Binary auto-discovery works (tested with `cargo install` on PATH)
- [x] MCP config is written correctly to `~/.pi/agent/mcp.json`
- [x] All 18 MCP tools are exposed through the MCP gateway
- [x] `computer_use_linux_doctor`, `computer_use_linux_list_windows`, `computer_use_linux_click` verified end-to-end
- [x] AT-SPI accessibility tree extraction works (tested with Firefox, Telegram Desktop on Hyprland)
- [x] `npm pack --dry-run` includes all new files
- [x] Skill loads correctly and shows host-specific references

## Notes

- This is a non-breaking addition — existing Hermes, Claude Desktop, Codex, and npm usage is unaffected
- The `.gitignore` change (`.agent-shell/` and `.agent-docs`) is a pre-existing local modification, unrelated to this feature
- AT-SPI accessibility requires `toolkit-accessibility = true` (runnable via `gsettings` or Hyprland `exec-once`)

Fixes: N/A — feature addition