### PR TITLE
fix: improve Hyprland 0.55 and MCP schema compatibility

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -66,6 +66,50 @@ pub struct ComputerUseLinux {
     desktop_size: Arc<Mutex<Option<(u32, u32)>>>,
 }
 
+fn sanitize_unsigned_integer_formats(value: &mut serde_json::Value) {
+    let serde_json::Value::Object(object) = value else {
+        return;
+    };
+
+    let has_unsigned_format = matches!(
+        object.get("format").and_then(serde_json::Value::as_str),
+        Some("uint" | "uint8" | "uint16" | "uint32" | "uint64" | "usize")
+    );
+    if has_unsigned_format {
+        object.remove("format");
+    }
+
+    for nested in object.values_mut() {
+        match nested {
+            serde_json::Value::Object(_) => sanitize_unsigned_integer_formats(nested),
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    sanitize_unsigned_integer_formats(item);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl ComputerUseLinux {
+    fn mcp_tool_router(&self) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
+        let mut router = Self::tool_router();
+        for route in router.map.values_mut() {
+            let input_schema = Arc::make_mut(&mut route.attr.input_schema);
+            for value in input_schema.values_mut() {
+                sanitize_unsigned_integer_formats(value);
+            }
+            if let Some(output_schema) = route.attr.output_schema.as_mut() {
+                for value in Arc::make_mut(output_schema).values_mut() {
+                    sanitize_unsigned_integer_formats(value);
+                }
+            }
+        }
+        router
+    }
+}
+
 #[tool_router]
 impl ComputerUseLinux {
     #[tool(
@@ -1287,6 +1331,7 @@ impl ComputerUseLinux {
 }
 
 #[tool_handler(
+    router = self.mcp_tool_router(),
     name = "computer-use-linux",
     // NOTE: keep in lockstep with Cargo.toml + package.json on every release.
     // The rmcp tool_handler macro only accepts a string literal here, so this
@@ -3742,6 +3787,49 @@ mod tests {
     use super::*;
     use crate::atspi_tree::{AccessibilityAction, Bounds};
     use crate::windows::{WindowBounds, GNOME_SHELL_EXTENSION_BACKEND};
+
+    #[test]
+    fn exported_tool_schemas_omit_unsigned_integer_formats() {
+        let tools = ComputerUseLinux::default().mcp_tool_router().list_all();
+        let value = serde_json::to_value(tools).unwrap();
+        let mut unsupported = Vec::new();
+        collect_unsigned_integer_formats(&value, "$", &mut unsupported);
+
+        assert!(
+            unsupported.is_empty(),
+            "unsupported unsigned integer formats: {unsupported:?}"
+        );
+    }
+
+    fn collect_unsigned_integer_formats(
+        value: &serde_json::Value,
+        path: &str,
+        unsupported: &mut Vec<String>,
+    ) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if matches!(
+                    object.get("format").and_then(serde_json::Value::as_str),
+                    Some("uint" | "uint8" | "uint16" | "uint32" | "uint64" | "usize")
+                ) {
+                    unsupported.push(path.to_string());
+                }
+                for (key, nested) in object {
+                    collect_unsigned_integer_formats(nested, &format!("{path}/{key}"), unsupported);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (index, nested) in items.iter().enumerate() {
+                    collect_unsigned_integer_formats(
+                        nested,
+                        &format!("{path}/{index}"),
+                        unsupported,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
 
     fn node(index: u32, bounds: Option<Bounds>) -> AccessibilityNode {
         node_with_actions(index, bounds, Vec::new())

--- a/src/windowing/backends/hyprland.rs
+++ b/src/windowing/backends/hyprland.rs
@@ -83,16 +83,28 @@ pub(crate) fn parse_hyprland_clients(json: &str) -> Result<Vec<WindowInfo>> {
 
 pub fn activate_window(window_id: u64) -> Result<()> {
     let address = format!("address:0x{window_id:x}");
-    let output = hyprctl_output(&["dispatch", "focuswindow", &address])
+    let lua_dispatch = lua_focus_dispatch(&address);
+    let lua_output = hyprctl_output(&["dispatch", &lua_dispatch])
+        .with_context(|| format!("failed to run Hyprland Lua focus dispatcher for {address}"))?;
+    if lua_output.status.success() {
+        return Ok(());
+    }
+
+    let legacy_output = hyprctl_output(&["dispatch", "focuswindow", &address])
         .with_context(|| format!("failed to run hyprctl dispatch focuswindow {address}"))?;
-    if output.status.success() {
+    if legacy_output.status.success() {
         Ok(())
     } else {
         bail!(
-            "hyprctl dispatch focuswindow {address} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            "Hyprland window focus failed for {address}; Lua dispatcher: {}; legacy dispatcher: {}",
+            String::from_utf8_lossy(&lua_output.stderr).trim(),
+            String::from_utf8_lossy(&legacy_output.stderr).trim()
         );
     }
+}
+
+fn lua_focus_dispatch(address: &str) -> String {
+    format!("hl.dsp.focus({{ window = \"{address}\" }})")
 }
 
 fn hyprctl_output(args: &[&str]) -> std::io::Result<std::process::Output> {
@@ -258,6 +270,14 @@ fn parse_hyprland_address(address: &str) -> Result<u64> {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    #[test]
+    fn builds_hyprland_055_lua_focus_dispatch() {
+        assert_eq!(
+            lua_focus_dispatch("address:0x1234abcd"),
+            "hl.dsp.focus({ window = \"address:0x1234abcd\" })"
+        );
+    }
 
     #[test]
     fn selects_wayland_matching_hyprland_instance_before_newer_nonmatch() {


### PR DESCRIPTION
## Summary

- use Hyprland 0.55's Lua focus dispatcher before falling back to the legacy `focuswindow` dispatcher
- remove Rust-specific unsigned integer `format` annotations from exported MCP input and output schemas
- add regression coverage for both the Lua expression and exported tool schemas

## Motivation

Hyprland 0.55.4 rejects the legacy command used for exact window targeting:

```text
hyprctl dispatch focuswindow address:0x...
')' expected near 'address'
```

The supported 0.55 form is:

```text
hyprctl dispatch 'hl.dsp.focus({ window = "address:0x..." })'
```

The Lua-first/legacy-fallback order keeps older Hyprland releases working.

Separately, `schemars` emits `uint`, `uint8`, `uint32`, and `uint64` formats throughout tool schemas. These are not standard JSON Schema formats and produce repeated warnings in MCP clients. The export-boundary sanitizer removes only those format annotations while preserving integer types and numeric constraints.

## Validation

Manually validated on Hyprland 0.55.4, including cross-workspace exact focus.

```text
cargo fmt --all -- --check
cargo check --locked --all-targets
cargo clippy --locked --all-targets -- -D warnings
cargo test --locked --no-fail-fast
python3 scripts/mcp_safety_check.py
```

Results: 134 library tests passed; MCP safety check passed for all 18 tools. The schema regression test confirms no unsupported unsigned formats remain in either input or output schemas.
