### PR TITLE
feat(windowing): add niri compositor window backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </p>
 </div>
 
-`computer-use-linux` reads accessibility trees, takes screenshots, and drives clicks, scrolls, and keystrokes across GNOME, KDE/KWin, Hyprland, i3, and COSMIC — Wayland-first, X11 best-effort.
+`computer-use-linux` reads accessibility trees, takes screenshots, and drives clicks, scrolls, and keystrokes across GNOME, KDE/KWin, Hyprland, i3, niri, and COSMIC — Wayland-first, X11 best-effort.
 
 ```bash
 npm install -g @agent-sh/computer-use-linux
@@ -25,7 +25,7 @@ The Rust crate is published as [`computer-use-linux`](https://crates.io/crates/c
 Most computer-use MCP servers are macOS-only (they lean on AppKit, AXUIElement, CGEvent). The few that target Linux either drive `xdotool` against an X11 root window or shell out to OCR over screenshots. Four things set this one apart:
 
 - **Wayland actually works.** Pointer actions can use the `org.freedesktop.portal.RemoteDesktop` interface on Wayland, with `ydotool` / `ydotoold` (uinput) as the deterministic fallback and keyboard/text path. Screenshots use the GNOME Shell DBus screenshot method when present, `org.freedesktop.portal.Screenshot` otherwise, and fall back to spawning `gnome-screenshot` for background/systemd contexts where both DBus paths are denied.
-- **Window targeting is compositor-aware.** The window registry tries GNOME Shell extension, GNOME Shell Introspect, COSMIC Wayland helper, KWin DBus scripting, Hyprland `hyprctl`, and i3 IPC in order, then reports exactly which backend won or why each backend failed.
+- **Window targeting is compositor-aware.** The window registry tries GNOME Shell extension, GNOME Shell Introspect, COSMIC Wayland helper, KWin DBus scripting, Hyprland `hyprctl`, i3 IPC, and niri `niri msg` in order, then reports exactly which backend won or why each backend failed.
 - **Semantic selectors, not pixel coordinates.** Tools like `click`, `perform_action`, and `set_value` accept `role` / `name` / `text` / `states` selectors backed by AT-SPI. Pixel coordinates remain available as a fallback for rendering-only surfaces (canvas, games, X clients without ATK).
 - **One JSON readiness report.** `computer-use-linux doctor` returns a structured document covering platform, portals, AT-SPI, windowing, input, and a `readiness` summary with explicit blockers and a recommended next step. MCP hosts can render or surface that to the user without parsing prose.
 
@@ -108,6 +108,7 @@ Validated manually on Ubuntu 25.10 (GNOME Shell 50.1, Wayland). Other compositor
 | KDE Plasma / KWin | temporary KWin DBus scripting | Lists and focuses windows through `org.kde.KWin` scripting when the session bus exposes it. |
 | Hyprland | `hyprctl clients -j` and `hyprctl dispatch focuswindow` | Requires `hyprctl` in the desktop session. |
 | i3 | `i3-msg`; optional `xprop` for PID hydration | Lists and focuses i3 windows over the active i3 IPC socket. |
+| niri | `niri msg --json windows` and `niri msg action focus-window --id` | Requires the `niri` binary in the desktop session. `bounds.x`/`bounds.y` are null for windows on workspaces that are not currently rendered (niri reports `tile_pos_in_workspace_view: null` for those); size is always populated. |
 | COSMIC Wayland | `computer-use-linux-cosmic` helper | Installed automatically by `./install.sh`, `cargo install`, and npm. For custom/manual layouts, put the helper next to the main binary, on `PATH`, or point `COMPUTER_USE_LINUX_COSMIC_HELPER` at it. |
 | Sway / generic wlroots | no dedicated backend yet | AT-SPI, screenshots, and global `ydotool` input can still work; exact window list/focus is currently unavailable unless another backend applies. |
 | Generic X11 / XFCE / other WMs | no dedicated backend yet | AT-SPI plus `ydotool` global input only, unless running under i3. |
@@ -312,7 +313,7 @@ Spawn the binary with `["mcp"]` as the argv tail. It speaks JSON-RPC over stdio 
 
    You may need to restart toolkit-using apps for the change to take effect.
 
-3. **If `windowing.can_list_windows = false`** — inspect `doctor.windowing.backends`. On GNOME Wayland, run `computer-use-linux setup-window-targeting` (or call `setup_window_targeting`) to install the bundled `computer-use-linux@avifenesh.dev` Shell extension, then log out and back in so GNOME Shell loads it. On KDE, Hyprland, i3, or COSMIC, install or expose the matching compositor tool/helper shown in the backend details.
+3. **If `windowing.can_list_windows = false`** — inspect `doctor.windowing.backends`. On GNOME Wayland, run `computer-use-linux setup-window-targeting` (or call `setup_window_targeting`) to install the bundled `computer-use-linux@avifenesh.dev` Shell extension, then log out and back in so GNOME Shell loads it. On KDE, Hyprland, i3, niri, or COSMIC, install or expose the matching compositor tool/helper shown in the backend details.
 
 4. **Grant the screencast portal on first screenshot.** The first time `get_app_state` or any screenshot subcommand runs, GNOME will pop a portal dialog asking to share the screen. Accept once and tick "remember" to make it sticky for the session.
 
@@ -359,7 +360,7 @@ files.
 - **DBus where desktops expose it** — [`zbus`](https://crates.io/crates/zbus) for portal calls (`org.freedesktop.portal.Screenshot`, `…RemoteDesktop`, `…ScreenCast`), GNOME Shell screenshots (`org.gnome.Shell.Screenshot`), the bundled GNOME extension's `dev.avifenesh.ComputerUseLinux.WindowControl` service, and temporary KWin scripting.
 - **MCP transport** — [`rmcp`](https://crates.io/crates/rmcp) with the `transport-io` feature; stdio framing, no network.
 - **Input fallback** — when the remote-desktop portal isn't available or the host wants deterministic injection, the binary writes to `ydotoold`'s socket, which writes to `/dev/uinput`. `install.sh` can configure `ydotoold`; the `setup` command only enables the GNOME AT-SPI bridge.
-- **Window registry** — `list_windows`, `focused_window`, `activate_window`, `press_key`, and `type_text` share a backend registry. It tries GNOME extension, GNOME Introspect, COSMIC helper, KWin scripting, Hyprland `hyprctl`, and i3 IPC in that order, skipping empty or failed backends so another compositor backend can answer.
+- **Window registry** — `list_windows`, `focused_window`, `activate_window`, `press_key`, and `type_text` share a backend registry. It tries GNOME extension, GNOME Introspect, COSMIC helper, KWin scripting, Hyprland `hyprctl`, i3 IPC, and niri `niri msg` in that order, skipping empty or failed backends so another compositor backend can answer.
 - **GNOME extension fallback** — recent GNOME builds deny `org.gnome.Shell.Introspect.GetWindows` to non-blessed clients. The bundled Shell extension exposes window data and exact activation under `dev.avifenesh.ComputerUseLinux.WindowControl`.
 - **COSMIC helper** — `computer-use-linux-cosmic` talks to COSMIC toplevel protocols and is resolved from `COMPUTER_USE_LINUX_COSMIC_HELPER`, next to the running binary, or from `PATH`.
 - **Terminal enrichment** — `list_windows` cross-references each terminal window with its controlling TTY and the foreground process on that TTY, so `type_text` / `press_key` can target "the terminal where `pytest` is running" without the host ever knowing the window id.
@@ -386,7 +387,7 @@ If you're running this on a shared workstation, set `ydotoold`'s socket permissi
 - **`input.ydotool_socket.ok = false`** — daemon isn't running. Fix: `systemctl --user enable --now ydotoold`. If the unit doesn't exist, install the `ydotool` package and rerun `./install.sh` (or copy the unit from `systemd/ydotoold.service` in this repo).
 - **`input.uinput.ok = false`** — `/dev/uinput` isn't accessible to your user. Fix: add yourself to the `input` group (`sudo usermod -aG input $USER`) and re-login. On distros that ship `uinput` as a kernel module without auto-loading it, add `uinput` to `/etc/modules-load.d/`.
 - **Portal calls hang or time out** — `xdg-desktop-portal` or its backend (`-gnome`, `-gtk`, `-kde`, `-wlr`) crashed. Fix: check `journalctl --user -u xdg-desktop-portal -u xdg-desktop-portal-gnome --since '5 min ago'` and restart the relevant unit.
-- **KWin / Hyprland / i3 / COSMIC windowing is unavailable** — check `doctor.windowing.backends`. KWin needs session-bus scripting; Hyprland needs `hyprctl`; i3 needs `i3-msg` and its IPC socket. COSMIC needs `computer-use-linux-cosmic`, which the standard installers provide automatically; if you copied binaries by hand, copy the helper too or set `COMPUTER_USE_LINUX_COSMIC_HELPER`.
+- **KWin / Hyprland / i3 / niri / COSMIC windowing is unavailable** — check `doctor.windowing.backends`. KWin needs session-bus scripting; Hyprland needs `hyprctl`; i3 needs `i3-msg` and its IPC socket. niri needs the `niri` binary in the session. COSMIC needs `computer-use-linux-cosmic`, which the standard installers provide automatically; if you copied binaries by hand, copy the helper too or set `COMPUTER_USE_LINUX_COSMIC_HELPER`.
 - **Screenshots return black frames on multi-monitor setups** — known portal / compositor edge case. Use `get_app_state` with `include_screenshot: false` and rely on AT-SPI until the portal backend is healthy.
 - **`type_text` types into the wrong window** — pass an explicit target (`window_id`, `pid`, `wm_class`, `title`, or for terminals `tty` / `terminal_pid` / `terminal_command` / `terminal_cwd`). Without a target, input goes to whatever window currently has compositor focus.
 

--- a/install.sh
+++ b/install.sh
@@ -168,6 +168,7 @@ detect_distro() {
     local desktop="${XDG_CURRENT_DESKTOP:-unknown}"
     case "${desktop}" in
         *GNOME*)         log_ok "compositor: GNOME (${desktop})" ;;
+        *niri*)          log_ok "compositor: niri (${desktop}) — window backend via niri msg" ;;
         *KDE*|*Plasma*)  log_warn "compositor: KDE (${desktop}) — untested, AT-SPI step will be skipped" ;;
         *sway*)          log_warn "compositor: sway — untested" ;;
         *Hyprland*)      log_warn "compositor: hyprland — untested" ;;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::windowing::registry::{
     self, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, X11_BACKEND,
+    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, NIRI_BACKEND, X11_BACKEND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -255,6 +255,13 @@ fn capability_map(
         .is_some_and(|check| check.ok)
     {
         window_backends.push(I3_BACKEND.to_string());
+    }
+    if windowing
+        .backends
+        .get(NIRI_BACKEND)
+        .is_some_and(|check| check.ok)
+    {
+        window_backends.push(NIRI_BACKEND.to_string());
     }
     if windowing
         .backends
@@ -609,6 +616,11 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
             "A KWin/Plasma window backend is available for list_windows, focused_window, and targeted input verification."
         } else if hyprland.ok {
             "A Hyprland window backend is available for list_windows, focused_window, and targeted input verification."
+        } else if backends
+            .get(NIRI_BACKEND)
+            .is_some_and(|check| check.ok)
+        {
+            "A niri window backend is available for list_windows, focused_window, and targeted input verification."
         } else {
             "A window listing backend is available for list_windows, focused_window, and targeted input verification."
         }

--- a/src/windowing/backends/mod.rs
+++ b/src/windowing/backends/mod.rs
@@ -3,4 +3,5 @@ pub mod gnome;
 pub mod hyprland;
 pub mod i3;
 pub mod kwin;
+pub mod niri;
 pub mod x11;

--- a/src/windowing/backends/niri.rs
+++ b/src/windowing/backends/niri.rs
@@ -1,0 +1,255 @@
+use crate::terminal::enrich_terminal_windows;
+use crate::windowing::registry::BackendProbe;
+use crate::windowing::types::{WindowBounds, WindowInfo};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::process::Command;
+
+pub const NIRI_BACKEND: &str = "niri";
+
+/// Probe the running niri compositor by asking it for its window list.
+///
+/// `niri msg --json windows` only succeeds when niri is the active
+/// compositor for this session (it auto-detects its socket from
+/// `WAYLAND_DISPLAY` + `XDG_RUNTIME_DIR`), so a failed probe cleanly
+/// disables the backend on non-niri sessions.
+pub fn probe() -> BackendProbe {
+    match niri_msg(&["--json", "windows"]) {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let ok = matches!(
+                serde_json::from_str::<serde_json::Value>(&stdout),
+                Ok(serde_json::Value::Array(_))
+            );
+            BackendProbe {
+                id: NIRI_BACKEND,
+                ok,
+                can_list_windows: ok,
+                can_focus_apps: ok,
+                can_focus_windows: ok,
+                detail: if ok {
+                    "niri msg --json windows returned a JSON array".to_string()
+                } else {
+                    "niri msg --json windows did not return a JSON array".to_string()
+                },
+            }
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            BackendProbe {
+                id: NIRI_BACKEND,
+                ok: false,
+                can_list_windows: false,
+                can_focus_apps: false,
+                can_focus_windows: false,
+                detail: if stderr.is_empty() { stdout } else { stderr },
+            }
+        }
+        Err(error) => BackendProbe {
+            id: NIRI_BACKEND,
+            ok: false,
+            can_list_windows: false,
+            can_focus_apps: false,
+            can_focus_windows: false,
+            detail: error.to_string(),
+        },
+    }
+}
+
+pub fn list_windows() -> Result<Vec<WindowInfo>> {
+    let output = niri_msg(&["--json", "windows"])
+        .context("failed to run niri msg --json windows")?;
+    if !output.status.success() {
+        bail!(
+            "niri msg --json windows failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let windows_json = String::from_utf8_lossy(&output.stdout);
+    parse_niri_windows(&windows_json)
+}
+
+pub(crate) fn parse_niri_windows(json: &str) -> Result<Vec<WindowInfo>> {
+    let niri_windows: Vec<NiriWindow> =
+        serde_json::from_str(json).context("failed to parse niri msg --json windows output")?;
+    let mut windows = niri_windows
+        .into_iter()
+        .map(WindowInfo::try_from)
+        .collect::<Result<Vec<_>>>()?;
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+pub fn activate_window(window_id: u64) -> Result<()> {
+    let id_arg = window_id.to_string();
+    let output = niri_msg(&["action", "focus-window", "--id", &id_arg])
+        .with_context(|| format!("failed to run niri msg action focus-window --id {window_id}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!(
+            "niri focus-window failed for id {window_id}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+fn niri_msg(args: &[&str]) -> std::io::Result<std::process::Output> {
+    Command::new("niri").arg("msg").args(args).output()
+}
+
+#[derive(Debug, Deserialize)]
+struct NiriWindow {
+    id: u64,
+    title: Option<String>,
+    app_id: Option<String>,
+    pid: Option<i64>,
+    workspace_id: Option<i64>,
+    is_focused: Option<bool>,
+    layout: Option<NiriLayout>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NiriLayout {
+    /// `[width, height]` in logical pixels. niri emits these as integers
+    /// but the schema permits floats, so parse as `f64` and round.
+    window_size: Option<[f64; 2]>,
+    /// Absolute position of the tile within the workspace view, in logical
+    /// pixels. `null` when niri does not expose a position for the window
+    /// (e.g. windows on workspaces that are not currently rendered).
+    tile_pos_in_workspace_view: Option<[f64; 2]>,
+}
+
+impl TryFrom<NiriWindow> for WindowInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(window: NiriWindow) -> Result<Self> {
+        let bounds = window.layout.and_then(|layout| {
+            let window_size = layout.window_size?;
+            let (width, height) = (window_size[0], window_size[1]);
+            if width <= 0.0 || height <= 0.0 {
+                return None;
+            }
+            let (x, y) = layout
+                .tile_pos_in_workspace_view
+                .map(|[x, y]| (Some(x.round() as i32), Some(y.round() as i32)))
+                .unwrap_or((None, None));
+            Some(WindowBounds {
+                x,
+                y,
+                width: width.round() as u32,
+                height: height.round() as u32,
+            })
+        });
+
+        let app_id = window.app_id;
+        Ok(WindowInfo {
+            window_id: window.id,
+            title: window.title,
+            app_id: app_id.clone(),
+            wm_class: app_id,
+            pid: window.pid.and_then(|pid| u32::try_from(pid).ok()),
+            bounds,
+            workspace: window.workspace_id.and_then(|id| i32::try_from(id).ok()),
+            focused: window.is_focused.unwrap_or(false),
+            hidden: false,
+            client_type: Some("wayland".to_string()),
+            backend: NIRI_BACKEND.to_string(),
+            terminal: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_tiled_window_with_size_but_no_absolute_position() {
+        let json = r#"[{
+            "id": 16,
+            "title": "~",
+            "app_id": "kitty",
+            "pid": 2872402,
+            "workspace_id": 2,
+            "is_focused": false,
+            "is_floating": false,
+            "is_urgent": false,
+            "layout": {
+                "pos_in_scrolling_layout": [1, 1],
+                "tile_size": [945.0, 1024.0],
+                "window_size": [945, 1024],
+                "tile_pos_in_workspace_view": null,
+                "window_offset_in_tile": [0.0, 0.0]
+            },
+            "focus_timestamp": {"secs": 172427, "nanos": 771495935}
+        }]"#;
+        let windows = parse_niri_windows(json).unwrap();
+        let window = &windows[0];
+        assert_eq!(window.window_id, 16);
+        assert_eq!(window.app_id.as_deref(), Some("kitty"));
+        assert_eq!(window.wm_class.as_deref(), Some("kitty"));
+        assert_eq!(window.pid, Some(2872402));
+        assert_eq!(window.workspace, Some(2));
+        assert!(!window.focused);
+        assert_eq!(window.client_type.as_deref(), Some("wayland"));
+        assert_eq!(window.backend, NIRI_BACKEND);
+        let bounds = window.bounds.as_ref().unwrap();
+        assert_eq!((bounds.x, bounds.y), (None, None));
+        assert_eq!((bounds.width, bounds.height), (945, 1024));
+    }
+
+    #[test]
+    fn parses_absolute_position_when_niri_exposes_it() {
+        let json = r#"[{
+            "id": 4,
+            "title": "Term",
+            "app_id": "kitty",
+            "pid": 5024,
+            "workspace_id": 1,
+            "is_focused": true,
+            "is_floating": false,
+            "is_urgent": false,
+            "layout": {
+                "pos_in_scrolling_layout": [2, 1],
+                "tile_size": [1517.0, 1024.0],
+                "window_size": [1517, 1024],
+                "tile_pos_in_workspace_view": [3747.0, 0.0],
+                "window_offset_in_tile": [0.0, 0.0]
+            },
+            "focus_timestamp": {"secs": 177316, "nanos": 240211240}
+        }]"#;
+        let windows = parse_niri_windows(json).unwrap();
+        let window = &windows[0];
+        assert!(window.focused);
+        let bounds = window.bounds.as_ref().unwrap();
+        assert_eq!((bounds.x, bounds.y), (Some(3747), Some(0)));
+        assert_eq!((bounds.width, bounds.height), (1517, 1024));
+    }
+
+    #[test]
+    fn omits_bounds_when_window_size_is_missing() {
+        let json = r#"[{
+            "id": 7,
+            "title": "Signal",
+            "app_id": "signal",
+            "pid": 10164,
+            "workspace_id": 3,
+            "is_focused": false,
+            "is_floating": false,
+            "is_urgent": false,
+            "layout": {
+                "pos_in_scrolling_layout": [1, 1],
+                "tile_size": [1920.0, 1044.0],
+                "window_size": null,
+                "tile_pos_in_workspace_view": null,
+                "window_offset_in_tile": [0.0, 0.0]
+            }
+        }]"#;
+        let windows = parse_niri_windows(json).unwrap();
+        assert!(windows[0].bounds.is_none());
+    }
+}

--- a/src/windowing/mod.rs
+++ b/src/windowing/mod.rs
@@ -6,7 +6,8 @@ pub mod types;
 #[allow(unused_imports)]
 pub use registry::{
     COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, WINDOW_PERMISSION_HINT, X11_BACKEND,
+    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, NIRI_BACKEND, WINDOW_PERMISSION_HINT,
+    X11_BACKEND,
 };
 #[allow(unused_imports)]
 pub use target::{
@@ -55,6 +56,7 @@ mod tests {
                 KWIN_BACKEND,
                 HYPRLAND_BACKEND,
                 I3_BACKEND,
+                NIRI_BACKEND,
                 X11_BACKEND,
             ]
         );

--- a/src/windowing/registry.rs
+++ b/src/windowing/registry.rs
@@ -1,4 +1,4 @@
-use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin, x11};
+use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin, niri, x11};
 use crate::windowing::types::WindowInfo;
 use anyhow::{anyhow, Result};
 
@@ -7,9 +7,10 @@ pub use gnome::{GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND};
 pub use hyprland::HYPRLAND_BACKEND;
 pub use i3::I3_BACKEND;
 pub use kwin::KWIN_BACKEND;
+pub use niri::NIRI_BACKEND;
 pub use x11::X11_BACKEND;
 
-pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the computer-use-linux GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, or i3-msg. On GNOME, run setup_window_targeting to install the extension backend.";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the computer-use-linux GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, i3-msg, or niri msg. On GNOME, run setup_window_targeting to install the extension backend.";
 
 #[derive(Debug, Clone, Copy)]
 pub struct BackendDescriptor {
@@ -38,6 +39,7 @@ enum BackendKind {
     Kwin,
     Hyprland,
     I3,
+    Niri,
     X11,
 }
 
@@ -48,6 +50,7 @@ const BACKEND_ORDER: &[BackendKind] = &[
     BackendKind::Kwin,
     BackendKind::Hyprland,
     BackendKind::I3,
+    BackendKind::Niri,
     // Generic X11/EWMH: last, so a session-native backend always wins first.
     BackendKind::X11,
 ];
@@ -93,6 +96,13 @@ const DESCRIPTORS: &[BackendDescriptor] = &[
         failure_label: "i3",
         list_note: "Window list came from i3-msg. Terminal windows may include best-effort PTY and active-process context when xprop and the process tree are readable.",
         missing_hint: "On i3, ensure i3-msg can reach the active i3 IPC socket.",
+        can_exact_focus: true,
+    },
+    BackendDescriptor {
+        id: NIRI_BACKEND,
+        failure_label: "niri",
+        list_note: "Window list came from niri msg. Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
+        missing_hint: "On niri, ensure the niri binary is available in the session.",
         can_exact_focus: true,
     },
     BackendDescriptor {
@@ -164,6 +174,7 @@ async fn list_windows_for(backend: BackendKind) -> Result<Vec<WindowInfo>> {
         BackendKind::Kwin => kwin::list_windows().await,
         BackendKind::Hyprland => hyprland::list_windows(),
         BackendKind::I3 => i3::list_windows(),
+        BackendKind::Niri => niri::list_windows(),
         BackendKind::X11 => x11::list_windows(),
     }
 }
@@ -188,6 +199,7 @@ pub async fn activate_window(window: &WindowInfo) -> Result<()> {
         KWIN_BACKEND => kwin::activate_window(window.window_id).await,
         HYPRLAND_BACKEND => hyprland::activate_window(window.window_id),
         I3_BACKEND => i3::activate_window(window.window_id),
+        NIRI_BACKEND => niri::activate_window(window.window_id),
         X11_BACKEND => x11::activate_window(window.window_id),
         backend => Err(anyhow!(
             "Unsupported window backend for activation: {backend}"
@@ -231,6 +243,7 @@ pub fn probe_backends() -> Vec<BackendProbe> {
         kwin::probe(),
         hyprland::probe(),
         i3::probe(),
+        niri::probe(),
         x11::probe(),
     ]
 }
@@ -244,6 +257,7 @@ impl BackendKind {
             BackendKind::Kwin => KWIN_BACKEND,
             BackendKind::Hyprland => HYPRLAND_BACKEND,
             BackendKind::I3 => I3_BACKEND,
+            BackendKind::Niri => NIRI_BACKEND,
             BackendKind::X11 => X11_BACKEND,
         }
     }


### PR DESCRIPTION
# Add niri compositor window backend

## Summary

Adds a niri windowing backend so `computer-use-linux` works on the [niri](https://github.com/YaLTeR/niri) Wayland compositor — window listing, focused-window queries, and exact per-window activation. niri is a scrollable-tiling Wayland compositor with a growing userbase; until now it fell through to the generic X11 backend (which doesn't apply on a Wayland-only session) and `doctor` reported window introspection unavailable.

The backend shells out to niri's own IPC (`niri msg`), mirroring how the Hyprland backend uses `hyprctl`.

## Changes

- **New** `src/windowing/backends/niri.rs`:
  - `probe()` runs `niri msg --json windows`; succeeds only when niri is the active compositor (it auto-detects its socket from `WAYLAND_DISPLAY` + `XDG_RUNTIME_DIR`), so the backend cleanly disables on non-niri sessions.
  - `list_windows()` parses `niri msg --json windows` into `WindowInfo` — `id`, `title`, `app_id`, `pid`, `workspace`, `is_focused`, and `bounds` from `layout.window_size` + `layout.tile_pos_in_workspace_view`.
  - `activate_window(id)` runs `niri msg action focus-window --id <ID>`.
  - `can_exact_focus: true`. Three unit tests: tiled window with size but no absolute position, window with absolute position, and missing `window_size`.
- **Wiring**: `BackendKind::Niri` added to `BACKEND_ORDER` (before the generic X11/EWMH fallback), with a `BackendDescriptor`, and wired into `list_windows_for`, `activate_window`, `probe_backends`, and the `BackendKind::id()` match. Re-exported via `windowing::mod`, and the `registry_keeps_stable_backend_order` test updated.
- **Diagnostics**: niri added to the `window_backends` capability list (read from the probe map, like i3/X11 which have no dedicated `WindowingReport` field) and a `note` branch.
- **README**: niri added to the compositor list, the window-targeting bullet, the backend-details table, the window-registry internals, troubleshooting, and the `can_list_windows=false` remediation step.
- **install.sh**: `*niri*` recognised in compositor detection → `log_ok` instead of the generic "untested" warning.

## Caveat worth flagging

`layout.tile_pos_in_workspace_view` is `null` for windows on workspaces that niri is not currently rendering, so `bounds.x` / `bounds.y` are `null` for those windows (size is always populated). The off-screen window warnings in `server.rs` rely on absolute position, so they only fire for windows on the visible workspace. This matches niri's own data model and seemed the right trade-off vs. omitting bounds entirely; happy to adjust if you'd prefer different behaviour.

## Verification

Tested live on niri 26.04 (EndeavourOS, Wayland):

- `computer-use-linux windows` → real windows with `app_id` / `title` / `pid` / `bounds`, `backend: "niri"`.
- `activate_window` via the MCP server moves focus and the server verifies it through a fresh window query (`exact_window_focused: true`).
- `computer-use-linux doctor` → `can_query_windows`, `can_focus_apps`, `can_focus_windows` all `true`; `blockers: []`; recommended step "Computer Use is ready".
- Full test suite: **151 passed, 0 failed**.

## Commit

Single commit on branch `add-niri-window-backend`:

```
feat(windowing): add niri compositor window backend
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)