### PR TITLE
fix: improve Hyprland input reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hyprland window activation now checks `hyprctl dispatch` stdout instead of
+  trusting its exit status, so an exit-zero `Invalid dispatcher` response falls
+  through to the compatible focus dispatcher. (#62)
+- Modifier chords sent through the ydotool fallback now include a 100 ms
+  inter-event delay so applications such as Firefox do not drop simultaneous
+  modifier and key events. (#63)
+
 ## [0.4.2] - 2026-07-25
 
 ### Fixed

--- a/src/server.rs
+++ b/src/server.rs
@@ -1254,8 +1254,7 @@ impl ComputerUseLinux {
                 }
             }
         }
-        let mut args = vec!["key".to_string()];
-        args.extend(key_events);
+        let args = ydotool_key_args(key_events, !chord_modifiers.is_empty());
         let result = run_ydotool(&args).await.map(|output| vec![output]);
         let mut output = action_result_with_focus("press_key", result, received, focus.clone());
         if output.ok && focus.is_some() {
@@ -3979,6 +3978,15 @@ fn key_sequence(key: &str) -> Option<Vec<String>> {
     Some(events)
 }
 
+fn ydotool_key_args(key_events: Vec<String>, has_modifiers: bool) -> Vec<String> {
+    let mut args = vec!["key".to_string()];
+    if has_modifiers {
+        args.extend(["-d".to_string(), "100".to_string()]);
+    }
+    args.extend(key_events);
+    args
+}
+
 fn modifier_keycode(key: &str) -> Option<u16> {
     match normalize_key(key).as_str() {
         "ctrl" | "control" => Some(29),
@@ -5011,6 +5019,13 @@ mod tests {
                 "29:0".to_string(),
             ])
         );
+    }
+
+    #[test]
+    fn ydotool_modifier_chords_include_an_inter_event_delay() {
+        let args = ydotool_key_args(key_sequence("Ctrl+T").unwrap(), true);
+
+        assert_eq!(args, ["key", "-d", "100", "29:1", "20:1", "20:0", "29:0"]);
     }
 
     #[test]

--- a/src/windowing/backends/hyprland.rs
+++ b/src/windowing/backends/hyprland.rs
@@ -130,20 +130,39 @@ pub fn activate_window(window_id: u64) -> Result<()> {
     let lua_dispatch = lua_focus_dispatch(&address);
     let lua_output = hyprctl_output(&["dispatch", &lua_dispatch])
         .with_context(|| format!("failed to run Hyprland Lua focus dispatcher for {address}"))?;
-    if lua_output.status.success() {
+    if dispatch_succeeded(&lua_output) {
         return Ok(());
     }
 
     let legacy_output = hyprctl_output(&["dispatch", "focuswindow", &address])
         .with_context(|| format!("failed to run hyprctl dispatch focuswindow {address}"))?;
-    if legacy_output.status.success() {
+    if dispatch_succeeded(&legacy_output) {
         Ok(())
     } else {
         bail!(
             "Hyprland window focus failed for {address}; Lua dispatcher: {}; legacy dispatcher: {}",
-            String::from_utf8_lossy(&lua_output.stderr).trim(),
-            String::from_utf8_lossy(&legacy_output.stderr).trim()
+            command_detail(&lua_output),
+            command_detail(&legacy_output)
         );
+    }
+}
+
+fn dispatch_succeeded(output: &std::process::Output) -> bool {
+    output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "ok"
+}
+
+fn command_detail(output: &std::process::Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let detail = if stderr.trim().is_empty() {
+        stdout.trim()
+    } else {
+        stderr.trim()
+    };
+    if detail.is_empty() {
+        format!("exit status {}", output.status)
+    } else {
+        detail.to_string()
     }
 }
 
@@ -322,6 +341,7 @@ fn parse_hyprland_address(address: &str) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
 
     #[test]
@@ -352,6 +372,29 @@ mod tests {
             lua_focus_dispatch("address:0x1234abcd"),
             "hl.dsp.focus({ window = \"address:0x1234abcd\" })"
         );
+    }
+
+    #[test]
+    fn dispatch_rejects_exit_zero_error_output() {
+        let output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: b"Invalid dispatcher\n".to_vec(),
+            stderr: Vec::new(),
+        };
+
+        assert!(!dispatch_succeeded(&output));
+        assert_eq!(command_detail(&output), "Invalid dispatcher");
+    }
+
+    #[test]
+    fn dispatch_accepts_ok_output() {
+        let output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: b"ok\n".to_vec(),
+            stderr: Vec::new(),
+        };
+
+        assert!(dispatch_succeeded(&output));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require `hyprctl dispatch` stdout to report `ok`, allowing exit-zero dispatcher errors to reach the compatibility fallback
- add a 100 ms ydotool inter-event delay for modifier chords so Firefox and similar applications do not drop them
- add regression coverage and changelog entries

## Verification

- `cargo fmt --check`
- `cargo test --locked`
- `cargo clippy --locked -- -D warnings`
- `git diff --check`

Closes #62
Closes #63