### PR TITLE
Harden input routing and compositor integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- KWin window listing and activation now support both Plasma 6
+  (`windowList`/`activeWindow`) and Plasma 5 (`clientList`/`activeClient`).
+- ydotool is now used only when its CLI, daemon, and socket support the raw
+  event semantics Computer Use emits. Compatibility probing works without
+  `XDG_RUNTIME_DIR`, uses an isolated private socket, and rejects CLI errors
+  that are returned with a successful exit status.
+- X11 `xdotool type` now disables per-character delay, and a command that
+  starts but fails is no longer replayed through ydotool. The ydotool fallback
+  is limited to failures to launch xdotool, avoiding duplicate partial input.
+
 ## [0.4.3] - 2026-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,9 @@ dependencies = [
  "cosmic-protocols",
  "evdev",
  "futures-util",
+ "getrandom",
  "image",
+ "libc",
  "mimalloc",
  "rmcp",
  "schemars",
@@ -331,6 +333,7 @@ dependencies = [
  "tokio",
  "wayland-client",
  "wayland-protocols",
+ "wayland-protocols-wlr",
  "xkeysym",
  "zbus",
 ]
@@ -482,11 +485,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,17 @@ base64 = "0.22.1"
 evdev = "0.13.2"
 cosmic-protocols = { version = "0.2.0", default-features = false, features = ["client"] }
 futures-util = "0.3.32"
+getrandom = "0.4.2"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+libc = "0.2"
 rmcp = { version = "1.5.0", features = ["transport-io"] }
 schemars = "1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.51.1", features = ["macros", "process", "rt", "time"] }
+tokio = { version = "1.51.1", features = ["io-util", "macros", "process", "rt", "sync", "time"] }
 wayland-client = "0.31.11"
 wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
+wayland-protocols-wlr = { version = "0.3.12", features = ["client"] }
 xkeysym = "0.2.1"
 zbus = "5.14.0"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Rust crate is published as [`computer-use-linux`](https://crates.io/crates/c
 Most computer-use MCP servers are macOS-only (they lean on AppKit, AXUIElement, CGEvent). The few that target Linux either drive `xdotool` against an X11 root window or shell out to OCR over screenshots. Four things set this one apart:
 
 - **Wayland actually works.** Pointer actions can use the `org.freedesktop.portal.RemoteDesktop` interface on Wayland, with `ydotool` / `ydotoold` (uinput) as the deterministic fallback and keyboard/text path. Screenshots use the GNOME Shell DBus screenshot method when present, `org.freedesktop.portal.Screenshot` otherwise, and fall back to spawning `gnome-screenshot` for background/systemd contexts where both DBus paths are denied.
-- **Window targeting is compositor-aware.** The window registry tries GNOME Shell extension, GNOME Shell Introspect, COSMIC Wayland helper, KWin DBus scripting, Hyprland `hyprctl`, and i3 IPC in order, then reports exactly which backend won or why each backend failed.
+- **Window targeting is compositor-aware.** The window registry tries GNOME Shell extension, GNOME Shell Introspect, COSMIC Wayland helper, KWin DBus scripting, Hyprland `hyprctl`, i3 IPC, and generic X11/EWMH in order, then reports exactly which backend won or why each backend failed.
 - **Semantic selectors, not pixel coordinates.** Tools like `click`, `perform_action`, and `set_value` accept `role` / `name` / `text` / `states` selectors backed by AT-SPI. Pixel coordinates remain available as a fallback for rendering-only surfaces (canvas, games, X clients without ATK).
 - **One JSON readiness report.** `computer-use-linux doctor` returns a structured document covering platform, portals, AT-SPI, windowing, input, and a `readiness` summary with explicit blockers and a recommended next step. MCP hosts can render or surface that to the user without parsing prose.
 
@@ -104,13 +104,13 @@ Validated manually on Ubuntu 25.10 (GNOME Shell 50.1, Wayland). Other compositor
 | Desktop/session | Window backend | Notes |
 | --- | --- | --- |
 | GNOME Wayland | GNOME Shell extension first, `org.gnome.Shell.Introspect` fallback | Full target. The extension provides exact window activation when GNOME blocks native introspection; Introspect can list windows and focus apps by `app_id` when allowed. |
-| GNOME X11 | `org.gnome.Shell.Introspect` when allowed | AT-SPI and `ydotool` work; the bundled GNOME Shell extension is only needed for GNOME Wayland. Exact per-window focus may be unavailable without the extension backend. |
-| KDE Plasma / KWin | temporary KWin DBus scripting | Lists and focuses windows through `org.kde.KWin` scripting when the session bus exposes it. |
+| GNOME X11 | `org.gnome.Shell.Introspect`, then generic X11/EWMH | AT-SPI works; keyboard input prefers `xdotool`/XTEST so the live XKB layout resolves keys correctly. |
+| KDE Plasma / KWin | temporary KWin DBus scripting | Lists and focuses windows through Plasma 5 or 6 `org.kde.KWin` scripting APIs when the session bus exposes them. |
 | Hyprland | `hyprctl clients -j` and `hyprctl dispatch focuswindow` | Requires `hyprctl` in the desktop session. |
 | i3 | `i3-msg`; optional `xprop` for PID hydration | Lists and focuses i3 windows over the active i3 IPC socket. |
 | COSMIC Wayland | `computer-use-linux-cosmic` helper | Installed automatically by `./install.sh`, `cargo install`, and npm. For custom/manual layouts, put the helper next to the main binary, on `PATH`, or point `COMPUTER_USE_LINUX_COSMIC_HELPER` at it. |
 | Sway / generic wlroots | no dedicated backend yet | AT-SPI, screenshots, and global `ydotool` input can still work; exact window list/focus is currently unavailable unless another backend applies. |
-| Generic X11 / XFCE / other WMs | no dedicated backend yet | AT-SPI plus `ydotool` global input only, unless running under i3. |
+| Generic X11 / XFCE / other EWMH WMs | `wmctrl` plus `xprop` | Lists, focuses, moves, and resizes windows; keyboard input prefers `xdotool`/XTEST. |
 
 If you run on a desktop not covered above, or a covered backend does not come up cleanly, please open an issue with the output of `computer-use-linux doctor` so we can extend the matrix honestly.
 
@@ -132,7 +132,7 @@ computer-use-linux doctor | jq .readiness
 
 ### Option B — `cargo install` (Rust binaries, no system setup)
 
-Installs the Rust binaries from crates.io. You still handle the system-level pieces yourself: `ydotoold`, AT-SPI, desktop portals, and the GNOME extension if you need the GNOME Wayland exact-focus backend.
+Installs the Rust binaries from crates.io. You still handle the system-level pieces yourself: AT-SPI, desktop portals, the optional `ydotoold` fallback, and the GNOME extension if you need the GNOME Wayland exact-focus backend.
 
 ```bash
 cargo install computer-use-linux
@@ -148,8 +148,8 @@ cargo install --git https://github.com/agent-sh/computer-use-linux
 Then, as needed:
 
 ```bash
-sudo apt install ydotool at-spi2-core         # or your distro's equivalent
-systemctl --user enable --now ydotoold
+sudo apt install ydotool at-spi2-core         # ydotool 1.0.3+ when using this fallback
+systemctl --user enable --now ydotoold         # only when doctor selects ydotool
 computer-use-linux setup                      # gsettings AT-SPI bridge
 computer-use-linux setup-window-targeting     # GNOME Shell extension
 ```
@@ -163,7 +163,7 @@ npm install -g @agent-sh/computer-use-linux
 computer-use-linux doctor
 ```
 
-You will still need `ydotoold` running and AT-SPI enabled (run `computer-use-linux setup` and the systemd commands above).
+You will still need AT-SPI enabled (`computer-use-linux setup`) and one input backend reported ready by `doctor`. Start `ydotoold` only when using the ydotool fallback.
 
 ### Option D — prebuilt binaries
 
@@ -312,11 +312,11 @@ Spawn the binary with `["mcp"]` as the argv tail. It speaks JSON-RPC over stdio 
 
    You may need to restart toolkit-using apps for the change to take effect.
 
-3. **If `windowing.can_list_windows = false`** — inspect `doctor.windowing.backends`. On GNOME Wayland, run `computer-use-linux setup-window-targeting` (or call `setup_window_targeting`) to install the bundled `computer-use-linux@avifenesh.dev` Shell extension, then log out and back in so GNOME Shell loads it. On KDE, Hyprland, i3, or COSMIC, install or expose the matching compositor tool/helper shown in the backend details.
+3. **If `windowing.can_list_windows = false`** — inspect `doctor.windowing.backends`. On GNOME Wayland, run `computer-use-linux setup-window-targeting` (or call `setup_window_targeting`) to install the bundled `computer-use-linux@avifenesh.dev` Shell extension, then log out and back in so GNOME Shell loads it. On KDE, Hyprland, i3, COSMIC, or generic X11, install or expose the matching compositor tool/helper shown in the backend details.
 
 4. **Grant the screencast portal on first screenshot.** The first time `get_app_state` or any screenshot subcommand runs, GNOME will pop a portal dialog asking to share the screen. Accept once and tick "remember" to make it sticky for the session.
 
-5. **Confirm `ydotoold` is running.**
+5. **Confirm compatible ydotool 1.0.3+ and `ydotoold` are available.**
 
    ```bash
    systemctl --user status ydotoold
@@ -336,6 +336,7 @@ Most setups need none of these — `doctor` and the installers pick sensible def
 | `CU_DISABLE_ABS_POINTER` | Disable the uinput absolute pointer and click through `ydotool` instead for setups where the abs-pointer device misbehaves. |
 | `COMPUTER_USE_LINUX_FORCE_PORTAL_POINTER` / `…_KEYBOARD` | Always route pointer / keyboard through the RemoteDesktop portal on Wayland, skipping auto-detection. |
 | `COMPUTER_USE_LINUX_FORCE_YDOTOOL_POINTER` / `…_KEYBOARD` | Always route pointer / keyboard through `ydotool`, skipping the portal and KDE clipboard paths. |
+| `COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD` | Prefer `xdotool`/XTEST keyboard input when `DISPLAY` is available. `COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD=1` takes precedence. |
 | `COMPUTER_USE_LINUX_SCREENSHOT_BACKEND` | Force a single screenshot backend, skipping the fallback chain. Accepts `gnome-shell`, `portal`, or `gnome-screenshot`. Pin `gnome-screenshot` for background/systemd contexts where the GNOME Shell and portal DBus paths are denied. |
 
 **Build-time identity overrides** (set while compiling a downstream embedded
@@ -358,8 +359,8 @@ files.
 - **Accessibility tree** — [`atspi`](https://crates.io/crates/atspi) crate (tokio backend) talks to the AT-SPI registry on the user session bus. The tree is flattened to `(role, name, text, states, bounds)` tuples and indexed; element indices are stable for the duration of a `get_app_state` snapshot.
 - **DBus where desktops expose it** — [`zbus`](https://crates.io/crates/zbus) for portal calls (`org.freedesktop.portal.Screenshot`, `…RemoteDesktop`, `…ScreenCast`), GNOME Shell screenshots (`org.gnome.Shell.Screenshot`), the bundled GNOME extension's `dev.avifenesh.ComputerUseLinux.WindowControl` service, and temporary KWin scripting.
 - **MCP transport** — [`rmcp`](https://crates.io/crates/rmcp) with the `transport-io` feature; stdio framing, no network.
-- **Input fallback** — when the remote-desktop portal isn't available or the host wants deterministic injection, the binary writes to `ydotoold`'s socket, which writes to `/dev/uinput`. `install.sh` can configure `ydotoold`; the `setup` command only enables the GNOME AT-SPI bridge.
-- **Window registry** — `list_windows`, `focused_window`, `activate_window`, `press_key`, and `type_text` share a backend registry. It tries GNOME extension, GNOME Introspect, COSMIC helper, KWin scripting, Hyprland `hyprctl`, and i3 IPC in that order, skipping empty or failed backends so another compositor backend can answer.
+- **Input fallback** — on X11, keyboard input prefers `xdotool`/XTEST and falls back only when xdotool cannot launch. On Wayland, when the remote-desktop portal isn't available or the host wants deterministic injection, the binary uses a compatible ydotool 1.0.3+ CLI and `ydotoold` socket, which writes to `/dev/uinput`. `install.sh` can configure `ydotoold`; the `setup` command only enables the GNOME AT-SPI bridge.
+- **Window registry** — `list_windows`, `focused_window`, `activate_window`, `press_key`, and `type_text` share a backend registry. It tries GNOME extension, GNOME Introspect, COSMIC helper, KWin scripting, Hyprland `hyprctl`, i3 IPC, and generic X11/EWMH in that order, skipping empty or failed backends so another compositor backend can answer.
 - **GNOME extension fallback** — recent GNOME builds deny `org.gnome.Shell.Introspect.GetWindows` to non-blessed clients. The bundled Shell extension exposes window data and exact activation under `dev.avifenesh.ComputerUseLinux.WindowControl`.
 - **COSMIC helper** — `computer-use-linux-cosmic` talks to COSMIC toplevel protocols and is resolved from `COMPUTER_USE_LINUX_COSMIC_HELPER`, next to the running binary, or from `PATH`.
 - **Terminal enrichment** — `list_windows` cross-references each terminal window with its controlling TTY and the foreground process on that TTY, so `type_text` / `press_key` can target "the terminal where `pytest` is running" without the host ever knowing the window id.
@@ -383,10 +384,11 @@ If you're running this on a shared workstation, set `ydotoold`'s socket permissi
 
 - **`accessibility.at_spi_bus.ok = false`** — AT-SPI registry isn't running or the toolkit bridge is off. Fix: `computer-use-linux setup` (or call the `setup_accessibility` MCP tool). Restart the apps you want to drive.
 - **`windowing.gnome_shell_introspect.ok = false` and `gnome_shell_extension_dbus.ok = false`** — GNOME blocks introspection and the extension isn't installed. Fix: `computer-use-linux setup-window-targeting`, then log out and log back in.
-- **`input.ydotool_socket.ok = false`** — daemon isn't running. Fix: `systemctl --user enable --now ydotoold`. If the unit doesn't exist, install the `ydotool` package and rerun `./install.sh` (or copy the unit from `systemd/ydotoold.service` in this repo).
+- **`input.ydotool_socket.ok = false` while ydotool is the selected fallback** — daemon isn't running. Fix: `systemctl --user enable --now ydotoold`. If the unit doesn't exist, install the `ydotool` package and rerun `./install.sh` (or copy the unit from `systemd/ydotoold.service` in this repo).
+- **`input.ydotool.ok = false` with an unsupported CLI message** — install ydotool 1.0.3 or newer. A running daemon or socket alone is not enough; `doctor` verifies the raw key, wheel, stdin typing, and absolute-movement command family before advertising the backend.
 - **`input.uinput.ok = false`** — `/dev/uinput` isn't accessible to your user. Fix: add yourself to the `input` group (`sudo usermod -aG input $USER`) and re-login. On distros that ship `uinput` as a kernel module without auto-loading it, add `uinput` to `/etc/modules-load.d/`.
 - **Portal calls hang or time out** — `xdg-desktop-portal` or its backend (`-gnome`, `-gtk`, `-kde`, `-wlr`) crashed. Fix: check `journalctl --user -u xdg-desktop-portal -u xdg-desktop-portal-gnome --since '5 min ago'` and restart the relevant unit.
-- **KWin / Hyprland / i3 / COSMIC windowing is unavailable** — check `doctor.windowing.backends`. KWin needs session-bus scripting; Hyprland needs `hyprctl`; i3 needs `i3-msg` and its IPC socket. COSMIC needs `computer-use-linux-cosmic`, which the standard installers provide automatically; if you copied binaries by hand, copy the helper too or set `COMPUTER_USE_LINUX_COSMIC_HELPER`.
+- **KWin / Hyprland / i3 / COSMIC / X11 windowing is unavailable** — check `doctor.windowing.backends`. KWin needs session-bus scripting; Hyprland needs `hyprctl`; i3 needs `i3-msg` and its IPC socket; generic X11 needs `wmctrl` and `xprop`. COSMIC needs `computer-use-linux-cosmic`, which the standard installers provide automatically; if you copied binaries by hand, copy the helper too or set `COMPUTER_USE_LINUX_COSMIC_HELPER`.
 - **Screenshots return black frames on multi-monitor setups** — known portal / compositor edge case. Use `get_app_state` with `include_screenshot: false` and rely on AT-SPI until the portal backend is healthy.
 - **`type_text` types into the wrong window** — pass an explicit target (`window_id`, `pid`, `wm_class`, `title`, or for terminals `tty` / `terminal_pid` / `terminal_command` / `terminal_cwd`). Without a target, input goes to whatever window currently has compositor focus.
 

--- a/skills/computer-use-linux/SKILL.md
+++ b/skills/computer-use-linux/SKILL.md
@@ -41,10 +41,11 @@ If `doctor` reports missing input or accessibility support, run:
 
 ```bash
 computer-use-linux setup
-systemctl --user enable --now ydotoold
 computer-use-linux setup-window-targeting
 computer-use-linux doctor | jq .readiness
 ```
+
+If `doctor` selects ydotool as the input backend, also enable its per-user daemon with `systemctl --user enable --now ydotoold`. Direct uinput, X11 xdotool, and RemoteDesktop portal input do not require `ydotoold`.
 
 On GNOME Wayland, log out and back in after `setup-window-targeting` if the GNOME Shell extension was newly installed.
 
@@ -83,7 +84,8 @@ If the binary is not on `PATH`, use the absolute path (typically `~/.local/bin/c
 - GNOME may show a portal prompt on the first screenshot or `get_app_state` call with screenshots enabled.
 - Desktop input is stateful. Avoid concurrent tool calls against this MCP server.
 - `click`, `drag`, `press_key`, `type_text`, `perform_action`, and `set_value` can change real application state.
-- `ydotoold` should run as a per-user service with its socket under `/run/user/$UID`, not as a system-wide service.
+- When ydotool is selected, `ydotoold` should run as a per-user service with its socket under `/run/user/$UID`, not as a system-wide service.
+- The optional ydotool backend requires version 1.0.3 or newer; `doctor` rejects older or semantically incompatible CLIs even when `ydotoold` is running.
 - On COSMIC, the standard npm, Cargo, and install-script paths install the `computer-use-linux-cosmic` helper automatically. Manual binary installs must copy both binaries.
 
 ## Verification

--- a/src/bin/computer-use-linux-cosmic.rs
+++ b/src/bin/computer-use-linux-cosmic.rs
@@ -16,8 +16,11 @@ use wayland_client::{
 use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
     ext_foreign_toplevel_handle_v1, ext_foreign_toplevel_list_v1,
 };
+use wayland_protocols_wlr::output_management::v1::client::{
+    zwlr_output_head_v1, zwlr_output_manager_v1, zwlr_output_mode_v1,
+};
 
-const HELP: &str = "computer-use-linux-cosmic\n\nUsage:\n  computer-use-linux-cosmic probe\n  computer-use-linux-cosmic list-windows\n  computer-use-linux-cosmic focused-window\n  computer-use-linux-cosmic activate-window --window-id <id>";
+const HELP: &str = "computer-use-linux-cosmic\n\nUsage:\n  computer-use-linux-cosmic probe\n  computer-use-linux-cosmic list-windows\n  computer-use-linux-cosmic focused-window\n  computer-use-linux-cosmic monitor-layout\n  computer-use-linux-cosmic activate-window --window-id <id>";
 const BACKEND: &str = "cosmic-wayland";
 const ACTIVATION_STATE_TTL: Duration = Duration::from_secs(5);
 
@@ -64,6 +67,31 @@ struct ActivationState {
     timestamp_ms: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct MonitorInfo {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    scale: f64,
+}
+
+#[derive(Debug, Default)]
+struct OutputHeadState {
+    enabled: bool,
+    finished: bool,
+    position: Option<(i32, i32)>,
+    transform: Option<u32>,
+    scale: Option<f64>,
+    current_mode: Option<u32>,
+}
+
+#[derive(Debug, Default)]
+struct OutputModeState {
+    finished: bool,
+    size: Option<(i32, i32)>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct ToplevelRecord {
     foreign: Option<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1>,
@@ -104,6 +132,11 @@ struct AppData {
     records: Vec<ToplevelRecord>,
     by_foreign_id: HashMap<u32, usize>,
     by_cosmic_id: HashMap<u32, usize>,
+    output_manager: Option<zwlr_output_manager_v1::ZwlrOutputManagerV1>,
+    output_layout_ready: bool,
+    output_manager_finished: bool,
+    output_heads: HashMap<u32, OutputHeadState>,
+    output_modes: HashMap<u32, OutputModeState>,
 }
 
 fn main() -> Result<()> {
@@ -111,6 +144,7 @@ fn main() -> Result<()> {
         Command::Probe => print_json(&probe()?),
         Command::ListWindows => print_json(&collect_windows()?),
         Command::FocusedWindow => print_json(&focused_window()?),
+        Command::MonitorLayout => print_json(&monitor_layout()?),
         Command::ActivateWindow { window_id } => print_json(&activate_window(window_id)?),
     }
 }
@@ -120,6 +154,7 @@ enum Command {
     Probe,
     ListWindows,
     FocusedWindow,
+    MonitorLayout,
     ActivateWindow { window_id: u64 },
 }
 
@@ -129,6 +164,7 @@ impl Command {
             [command] if command == "probe" => Ok(Self::Probe),
             [command] if command == "list-windows" => Ok(Self::ListWindows),
             [command] if command == "focused-window" => Ok(Self::FocusedWindow),
+            [command] if command == "monitor-layout" => Ok(Self::MonitorLayout),
             [command, flag, value] if command == "activate-window" && flag == "--window-id" => {
                 Ok(Self::ActivateWindow {
                     window_id: value
@@ -144,7 +180,7 @@ impl Command {
                 println!("{HELP}");
                 std::process::exit(0);
             }
-            _ => bail!("unknown arguments. Expected one of: probe, list-windows, focused-window, activate-window --window-id <id>"),
+            _ => bail!("unknown arguments. Expected one of: probe, list-windows, focused-window, monitor-layout, activate-window --window-id <id>"),
         }
     }
 }
@@ -205,6 +241,10 @@ fn focused_window() -> Result<Option<WindowInfo>> {
     Ok(window)
 }
 
+fn monitor_layout() -> Result<Vec<MonitorInfo>> {
+    Snapshot::collect()?.monitor_layout()
+}
+
 fn activate_window(window_id: u64) -> Result<ActivationOutput> {
     let mut snapshot = Snapshot::collect()?;
     snapshot.activate(window_id)?;
@@ -235,6 +275,9 @@ impl Snapshot {
             .ok();
         snapshot.app_data.toplevel_manager = globals
             .bind::<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, _, _>(&qh, 1..=4, ())
+            .ok();
+        snapshot.app_data.output_manager = globals
+            .bind::<zwlr_output_manager_v1::ZwlrOutputManagerV1, _, _>(&qh, 1..=4, ())
             .ok();
         globals.contents().with_list(|entries| {
             for global in entries {
@@ -295,6 +338,17 @@ impl Snapshot {
             })
     }
 
+    fn monitor_layout(&self) -> Result<Vec<MonitorInfo>> {
+        if self.app_data.output_manager.is_none() {
+            bail!("COSMIC output management protocol is unavailable");
+        }
+        if self.app_data.output_manager_finished || !self.app_data.output_layout_ready {
+            bail!("COSMIC output management did not finish an atomic layout snapshot");
+        }
+        monitor_layout_from_state(&self.app_data.output_heads, &self.app_data.output_modes)
+            .ok_or_else(|| anyhow!("COSMIC output management returned an incomplete layout"))
+    }
+
     fn activate(&mut self, window_id: u64) -> Result<()> {
         if !self.can_activate_windows() {
             bail!("COSMIC activation capability is unavailable");
@@ -330,6 +384,145 @@ impl Snapshot {
             .roundtrip(&mut self.app_data)
             .context("Wayland roundtrip after activation failed")?;
         Ok(())
+    }
+}
+
+fn monitor_layout_from_state(
+    heads: &HashMap<u32, OutputHeadState>,
+    modes: &HashMap<u32, OutputModeState>,
+) -> Option<Vec<MonitorInfo>> {
+    let mut layout = heads
+        .values()
+        .filter(|head| head.enabled && !head.finished)
+        .map(|head| {
+            let (x, y) = head.position?;
+            let scale = head.scale?;
+            let mode = modes.get(&head.current_mode?)?;
+            if mode.finished || !scale.is_finite() || scale <= 0.0 {
+                return None;
+            }
+            let (mut width, mut height) = mode.size?;
+            if head.transform? % 2 == 1 {
+                std::mem::swap(&mut width, &mut height);
+            }
+            if width <= 0 || height <= 0 {
+                return None;
+            }
+            let width = (f64::from(width) / scale).round() as i32;
+            let height = (f64::from(height) / scale).round() as i32;
+            (width > 0 && height > 0).then_some(MonitorInfo {
+                x,
+                y,
+                width,
+                height,
+                scale,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    layout.sort_by_key(|monitor| (monitor.x, monitor.y, monitor.width, monitor.height));
+    (!layout.is_empty()).then_some(layout)
+}
+
+impl Dispatch<zwlr_output_manager_v1::ZwlrOutputManagerV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        _manager: &zwlr_output_manager_v1::ZwlrOutputManagerV1,
+        event: zwlr_output_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_output_manager_v1::Event::Head { head } => {
+                app_data.output_layout_ready = false;
+                app_data
+                    .output_heads
+                    .entry(head.id().protocol_id())
+                    .or_default();
+            }
+            zwlr_output_manager_v1::Event::Done { .. } => {
+                app_data.output_layout_ready = true;
+            }
+            zwlr_output_manager_v1::Event::Finished => {
+                app_data.output_layout_ready = false;
+                app_data.output_manager_finished = true;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    event_created_child!(
+        AppData,
+        zwlr_output_manager_v1::ZwlrOutputManagerV1,
+        [
+            zwlr_output_manager_v1::EVT_HEAD_OPCODE => (zwlr_output_head_v1::ZwlrOutputHeadV1, ()),
+        ]
+    );
+}
+
+impl Dispatch<zwlr_output_head_v1::ZwlrOutputHeadV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        head: &zwlr_output_head_v1::ZwlrOutputHeadV1,
+        event: zwlr_output_head_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        app_data.output_layout_ready = false;
+        let head_id = head.id().protocol_id();
+        let state = app_data.output_heads.entry(head_id).or_default();
+        match event {
+            zwlr_output_head_v1::Event::Mode { mode } => {
+                app_data
+                    .output_modes
+                    .entry(mode.id().protocol_id())
+                    .or_default();
+            }
+            zwlr_output_head_v1::Event::Enabled { enabled } => state.enabled = enabled != 0,
+            zwlr_output_head_v1::Event::CurrentMode { mode } => {
+                state.current_mode = Some(mode.id().protocol_id());
+            }
+            zwlr_output_head_v1::Event::Position { x, y } => state.position = Some((x, y)),
+            zwlr_output_head_v1::Event::Transform { transform } => {
+                state.transform = Some(transform.into());
+            }
+            zwlr_output_head_v1::Event::Scale { scale } => state.scale = Some(scale),
+            zwlr_output_head_v1::Event::Finished => state.finished = true,
+            _ => {}
+        }
+    }
+
+    event_created_child!(
+        AppData,
+        zwlr_output_head_v1::ZwlrOutputHeadV1,
+        [
+            zwlr_output_head_v1::EVT_MODE_OPCODE => (zwlr_output_mode_v1::ZwlrOutputModeV1, ()),
+        ]
+    );
+}
+
+impl Dispatch<zwlr_output_mode_v1::ZwlrOutputModeV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        mode: &zwlr_output_mode_v1::ZwlrOutputModeV1,
+        event: zwlr_output_mode_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        app_data.output_layout_ready = false;
+        let state = app_data
+            .output_modes
+            .entry(mode.id().protocol_id())
+            .or_default();
+        match event {
+            zwlr_output_mode_v1::Event::Size { width, height } => {
+                state.size = Some((width, height));
+            }
+            zwlr_output_mode_v1::Event::Finished => state.finished = true,
+            _ => {}
+        }
     }
 }
 
@@ -650,6 +843,111 @@ mod tests {
         .to_string();
 
         assert!(error.contains("invalid window id"));
+    }
+
+    #[test]
+    fn parses_monitor_layout_command() {
+        assert!(matches!(
+            Command::parse(vec!["monitor-layout".to_string()]).unwrap(),
+            Command::MonitorLayout
+        ));
+    }
+
+    #[test]
+    fn monitor_layout_uses_fractional_scale_and_transform() {
+        let heads = HashMap::from([
+            (
+                1,
+                OutputHeadState {
+                    enabled: true,
+                    position: Some((-1080, 0)),
+                    transform: Some(1),
+                    scale: Some(2.0),
+                    current_mode: Some(11),
+                    ..Default::default()
+                },
+            ),
+            (
+                2,
+                OutputHeadState {
+                    enabled: true,
+                    position: Some((0, 0)),
+                    transform: Some(0),
+                    scale: Some(1.25),
+                    current_mode: Some(22),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let modes = HashMap::from([
+            (
+                11,
+                OutputModeState {
+                    size: Some((3840, 2160)),
+                    ..Default::default()
+                },
+            ),
+            (
+                22,
+                OutputModeState {
+                    size: Some((2560, 1440)),
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            monitor_layout_from_state(&heads, &modes).unwrap(),
+            vec![
+                MonitorInfo {
+                    x: -1080,
+                    y: 0,
+                    width: 1080,
+                    height: 1920,
+                    scale: 2.0,
+                },
+                MonitorInfo {
+                    x: 0,
+                    y: 0,
+                    width: 2048,
+                    height: 1152,
+                    scale: 1.25,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn monitor_layout_rejects_an_incomplete_enabled_head() {
+        let heads = HashMap::from([
+            (
+                1,
+                OutputHeadState {
+                    enabled: true,
+                    position: Some((0, 0)),
+                    transform: Some(0),
+                    scale: Some(1.0),
+                    current_mode: Some(11),
+                    ..Default::default()
+                },
+            ),
+            (
+                2,
+                OutputHeadState {
+                    enabled: true,
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let modes = HashMap::from([(
+            11,
+            OutputModeState {
+                size: Some((1920, 1080)),
+                ..Default::default()
+            },
+        )]);
+
+        assert!(monitor_layout_from_state(&heads, &modes).is_none());
     }
 
     #[test]

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -1,0 +1,638 @@
+use anyhow::{anyhow, Context, Result};
+use std::{
+    io::{self, Read},
+    os::{fd::AsRawFd, unix::process::CommandExt as _},
+    process::{Command as StdCommand, Output, Stdio},
+    thread,
+    time::Instant as StdInstant,
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    process::{Child, Command},
+    sync::oneshot,
+    task::JoinHandle,
+    time::{Duration, Instant},
+};
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const REAP_TIMEOUT: Duration = Duration::from_secs(1);
+const MAX_COMMAND_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+const BLOCKING_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const MAX_BLOCKING_OUTPUT_BYTES: usize = 1024 * 1024;
+const MAX_BLOCKING_DRAIN_BYTES: usize = 64 * 1024;
+
+pub(crate) async fn output(command: Command, action: &str) -> Result<Output> {
+    output_with_timeout(command, action, COMMAND_TIMEOUT).await
+}
+
+pub(crate) async fn output_with_timeout(
+    command: Command,
+    action: &str,
+    timeout: Duration,
+) -> Result<Output> {
+    output_with_input(command, action, timeout, None).await
+}
+
+pub(crate) async fn output_with_stdin(
+    command: Command,
+    action: &str,
+    timeout: Duration,
+    input: Vec<u8>,
+) -> Result<Output> {
+    output_with_input(command, action, timeout, Some(input)).await
+}
+
+pub(crate) fn output_blocking_with_timeout(
+    command: &mut StdCommand,
+    action: &str,
+    timeout: Duration,
+) -> Result<Output> {
+    command
+        .process_group(0)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to {action}"))?;
+    let pgid = i32::try_from(child.id()).context("child process id did not fit in i32")?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .context("command stdout was not piped")?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .context("command stderr was not piped")?;
+    if let Err(error) =
+        set_nonblocking(stdout.as_raw_fd()).and_then(|()| set_nonblocking(stderr.as_raw_fd()))
+    {
+        terminate_blocking_process(&mut child, pgid);
+        return Err(error).with_context(|| format!("failed to configure {action} output pipes"));
+    }
+
+    let deadline = StdInstant::now() + timeout;
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+    let mut stdout_eof = false;
+    let mut stderr_eof = false;
+    loop {
+        if !stdout_eof {
+            match drain_nonblocking(&mut stdout, &mut stdout_bytes) {
+                Ok(eof) => stdout_eof = eof,
+                Err(error) => {
+                    terminate_blocking_process(&mut child, pgid);
+                    return Err(error)
+                        .with_context(|| format!("failed to collect {action} stdout"));
+                }
+            }
+        }
+        if !stderr_eof {
+            match drain_nonblocking(&mut stderr, &mut stderr_bytes) {
+                Ok(eof) => stderr_eof = eof,
+                Err(error) => {
+                    terminate_blocking_process(&mut child, pgid);
+                    return Err(error)
+                        .with_context(|| format!("failed to collect {action} stderr"));
+                }
+            }
+        }
+        if stdout_eof && stderr_eof {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return Ok(Output {
+                        status,
+                        stdout: stdout_bytes,
+                        stderr: stderr_bytes,
+                    });
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    terminate_blocking_process(&mut child, pgid);
+                    return Err(error).with_context(|| format!("failed to wait for {action}"));
+                }
+            }
+        }
+        if StdInstant::now() >= deadline {
+            terminate_blocking_process(&mut child, pgid);
+            return Err(timeout_error(action, timeout));
+        }
+        thread::sleep(BLOCKING_POLL_INTERVAL);
+    }
+}
+
+async fn output_with_input(
+    mut command: Command,
+    action: &str,
+    timeout: Duration,
+    input: Option<Vec<u8>>,
+) -> Result<Output> {
+    command
+        .kill_on_drop(true)
+        .process_group(0)
+        .stdin(if input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = command
+        .spawn()
+        .with_context(|| format!("failed to {action}"))?;
+    supervise_child(child, action, timeout, input).await
+}
+
+pub(crate) async fn output_child(child: Child, action: &str, timeout: Duration) -> Result<Output> {
+    supervise_child(child, action, timeout, None).await
+}
+
+async fn supervise_child(
+    mut child: Child,
+    action: &str,
+    timeout: Duration,
+    input: Option<Vec<u8>>,
+) -> Result<Output> {
+    let pid = child
+        .id()
+        .and_then(|pid| i32::try_from(pid).ok())
+        .context("spawned command did not have a usable process id")?;
+    let mut process_group = ProcessGroupGuard::new(pid);
+    let stdout = child
+        .stdout
+        .take()
+        .context("command stdout was not piped")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("command stderr was not piped")?;
+    let stdout_reader = tokio::spawn(read_pipe(stdout));
+    let stderr_reader = tokio::spawn(read_pipe(stderr));
+    let stdin_writer = match input {
+        Some(input) => {
+            let mut stdin = child.stdin.take().context("command stdin was not piped")?;
+            Some(tokio::spawn(async move { stdin.write_all(&input).await }))
+        }
+        None => None,
+    };
+
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    let deadline = Instant::now() + timeout;
+    let action = action.to_string();
+    tokio::spawn(async move {
+        supervise_command(
+            child,
+            &mut process_group,
+            stdout_reader,
+            stderr_reader,
+            stdin_writer,
+            cancel_rx,
+            deadline,
+            timeout,
+            &action,
+            result_tx,
+        )
+        .await;
+    });
+
+    let mut cancellation = CancelOnDrop(Some(cancel_tx));
+    let result = result_rx
+        .await
+        .context("command supervisor stopped before returning a result")?;
+    cancellation.0 = None;
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn supervise_command(
+    mut child: Child,
+    process_group: &mut ProcessGroupGuard,
+    mut stdout_reader: JoinHandle<std::io::Result<Vec<u8>>>,
+    mut stderr_reader: JoinHandle<std::io::Result<Vec<u8>>>,
+    mut stdin_writer: Option<JoinHandle<std::io::Result<()>>>,
+    mut cancel_rx: oneshot::Receiver<()>,
+    deadline: Instant,
+    timeout: Duration,
+    action: &str,
+    result_tx: oneshot::Sender<Result<Output>>,
+) {
+    enum Completion {
+        Finished(Result<Output>),
+        Timeout,
+        Cancelled,
+    }
+
+    let completion = {
+        // Keep the leader waitable until every inherited output descriptor is
+        // closed, so its process-group id cannot be reused during cleanup.
+        let command_completion = async {
+            let stdin = async {
+                match stdin_writer.as_mut() {
+                    Some(writer) => writer
+                        .await
+                        .context("command stdin writer task failed")?
+                        .context("failed to write command stdin"),
+                    None => Ok(()),
+                }
+            };
+            let stdout = async {
+                (&mut stdout_reader)
+                    .await
+                    .context("command stdout reader task failed")?
+                    .context("failed to read command stdout")
+            };
+            let stderr = async {
+                (&mut stderr_reader)
+                    .await
+                    .context("command stderr reader task failed")?
+                    .context("failed to read command stderr")
+            };
+            let ((), stdout, stderr) = tokio::try_join!(stdin, stdout, stderr)?;
+            let status = child.wait().await.context("failed to wait for command")?;
+            Ok(Output {
+                status,
+                stdout,
+                stderr,
+            })
+        };
+        tokio::pin!(command_completion);
+        tokio::select! {
+            result = &mut command_completion => Completion::Finished(result),
+            _ = tokio::time::sleep_until(deadline) => Completion::Timeout,
+            _ = &mut cancel_rx => Completion::Cancelled,
+        }
+    };
+
+    let result = match completion {
+        Completion::Finished(Ok(output)) => {
+            process_group.disarm();
+            Ok(output)
+        }
+        Completion::Finished(Err(error)) => {
+            terminate_command(
+                &mut child,
+                process_group,
+                &mut stdout_reader,
+                &mut stderr_reader,
+                stdin_writer.as_mut(),
+            )
+            .await;
+            Err(error).with_context(|| format!("failed to {action}"))
+        }
+        Completion::Timeout => {
+            terminate_command(
+                &mut child,
+                process_group,
+                &mut stdout_reader,
+                &mut stderr_reader,
+                stdin_writer.as_mut(),
+            )
+            .await;
+            Err(timeout_error(action, timeout))
+        }
+        Completion::Cancelled => {
+            terminate_command(
+                &mut child,
+                process_group,
+                &mut stdout_reader,
+                &mut stderr_reader,
+                stdin_writer.as_mut(),
+            )
+            .await;
+            Err(anyhow!("cancelled while trying to {action}"))
+        }
+    };
+    let _ = result_tx.send(result);
+}
+
+async fn read_pipe(mut pipe: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let length = pipe.read(&mut buffer).await?;
+        if length == 0 {
+            break;
+        }
+        if output.len().saturating_add(length) > MAX_COMMAND_OUTPUT_BYTES {
+            return Err(std::io::Error::other(format!(
+                "command output exceeded {MAX_COMMAND_OUTPUT_BYTES} bytes"
+            )));
+        }
+        output.extend_from_slice(&buffer[..length]);
+    }
+    Ok(output)
+}
+
+fn set_nonblocking(fd: std::os::fd::RawFd) -> io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn drain_nonblocking(reader: &mut impl Read, output: &mut Vec<u8>) -> io::Result<bool> {
+    let mut buffer = [0_u8; 8192];
+    let mut drained = 0;
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => return Ok(true),
+            Ok(length) => {
+                if output.len().saturating_add(length) > MAX_BLOCKING_OUTPUT_BYTES {
+                    return Err(io::Error::other(format!(
+                        "command output exceeded {MAX_BLOCKING_OUTPUT_BYTES} bytes"
+                    )));
+                }
+                output.extend_from_slice(&buffer[..length]);
+                drained += length;
+                if drained >= MAX_BLOCKING_DRAIN_BYTES {
+                    return Ok(false);
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(false),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn terminate_blocking_process(child: &mut std::process::Child, pgid: i32) {
+    unsafe {
+        libc::kill(-pgid, libc::SIGKILL);
+    }
+    let _ = child.kill();
+    let deadline = StdInstant::now() + REAP_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) if StdInstant::now() < deadline => thread::sleep(BLOCKING_POLL_INTERVAL),
+            Ok(None) => return,
+        }
+    }
+}
+
+async fn terminate_command(
+    child: &mut Child,
+    process_group: &mut ProcessGroupGuard,
+    stdout_reader: &mut JoinHandle<std::io::Result<Vec<u8>>>,
+    stderr_reader: &mut JoinHandle<std::io::Result<Vec<u8>>>,
+    stdin_writer: Option<&mut JoinHandle<std::io::Result<()>>>,
+) {
+    process_group.kill();
+    let _ = child.start_kill();
+    let _ = tokio::time::timeout(REAP_TIMEOUT, child.wait()).await;
+    stdout_reader.abort();
+    stderr_reader.abort();
+    if let Some(stdin_writer) = stdin_writer {
+        stdin_writer.abort();
+    }
+    process_group.disarm();
+}
+
+fn timeout_error(action: &str, timeout: Duration) -> anyhow::Error {
+    anyhow!(
+        "timed out after {} ms while trying to {action}",
+        timeout.as_millis()
+    )
+}
+
+struct ProcessGroupGuard {
+    pgid: i32,
+    armed: bool,
+}
+
+impl ProcessGroupGuard {
+    fn new(pgid: i32) -> Self {
+        Self { pgid, armed: true }
+    }
+
+    fn kill(&self) {
+        if self.armed {
+            unsafe {
+                libc::kill(-self.pgid, libc::SIGKILL);
+            }
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+struct CancelOnDrop(Option<oneshot::Sender<()>>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if let Some(cancel) = self.0.take() {
+            let _ = cancel.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::PathBuf, time::Instant};
+
+    #[tokio::test]
+    async fn timeout_kills_the_child_process() {
+        let pid_path = temporary_pid_path("leader");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!("printf %s $$ > '{}'; exec sleep 60", pid_path.display()),
+        ]);
+        let started = Instant::now();
+
+        let error = output_with_timeout(command, "run test child", Duration::from_millis(20))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_millis(500));
+        let pid = wait_for_pid(&pid_path).await;
+        wait_for_process_exit(pid).await;
+        let _ = fs::remove_file(pid_path);
+    }
+
+    #[tokio::test]
+    async fn timeout_kills_descendants_that_hold_output_pipes() {
+        let leader_path = temporary_pid_path("group-leader");
+        let descendant_path = temporary_pid_path("group-descendant");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!(
+                "printf %s $$ > '{}'; sleep 60 & printf %s $! > '{}'; wait",
+                leader_path.display(),
+                descendant_path.display()
+            ),
+        ]);
+
+        let error = output_with_timeout(command, "run process tree", Duration::from_millis(100))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
+        let leader = wait_for_pid(&leader_path).await;
+        let descendant = wait_for_pid(&descendant_path).await;
+        wait_for_process_exit(leader).await;
+        wait_for_process_exit(descendant).await;
+        let _ = fs::remove_file(leader_path);
+        let _ = fs::remove_file(descendant_path);
+    }
+
+    #[tokio::test]
+    async fn caller_cancellation_kills_the_process_group() {
+        let leader_path = temporary_pid_path("cancel-leader");
+        let descendant_path = temporary_pid_path("cancel-descendant");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!(
+                "printf %s $$ > '{}'; sleep 60 & printf %s $! > '{}'; wait",
+                leader_path.display(),
+                descendant_path.display()
+            ),
+        ]);
+        let task = tokio::spawn(output_with_timeout(
+            command,
+            "run cancellable process tree",
+            Duration::from_secs(60),
+        ));
+        let leader = wait_for_pid(&leader_path).await;
+        let descendant = wait_for_pid(&descendant_path).await;
+
+        task.abort();
+        let _ = task.await;
+
+        wait_for_process_exit(leader).await;
+        wait_for_process_exit(descendant).await;
+        let _ = fs::remove_file(leader_path);
+        let _ = fs::remove_file(descendant_path);
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_leader_exit_kills_pipe_holding_descendant() {
+        let descendant_path = temporary_pid_path("post-exit-descendant");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!(
+                "sleep 60 & printf %s $! > '{}'; exit 0",
+                descendant_path.display()
+            ),
+        ]);
+        let task = tokio::spawn(output_with_timeout(
+            command,
+            "collect descendant output",
+            Duration::from_secs(60),
+        ));
+        let descendant = wait_for_pid(&descendant_path).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !task.is_finished(),
+            "descendant should still hold output pipes"
+        );
+
+        task.abort();
+        let _ = task.await;
+
+        wait_for_process_exit(descendant).await;
+        let _ = fs::remove_file(descendant_path);
+    }
+
+    #[tokio::test]
+    async fn output_with_stdin_writes_and_closes_input() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "cat"]);
+
+        let output = output_with_stdin(
+            command,
+            "echo stdin",
+            Duration::from_secs(1),
+            b"portal input".to_vec(),
+        )
+        .await
+        .expect("stdin command should complete");
+
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"portal input");
+    }
+
+    #[tokio::test]
+    async fn command_output_is_bounded() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "head -c 9000000 /dev/zero"]);
+
+        let error =
+            output_with_timeout(command, "capture excessive output", Duration::from_secs(5))
+                .await
+                .unwrap_err();
+
+        assert!(format!("{error:#}").contains("output exceeded"));
+    }
+
+    #[tokio::test]
+    async fn command_output_drains_large_stdout_and_stderr() {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "yes stdout | head -c 200000; yes stderr | head -c 200000 >&2",
+        ]);
+
+        let output = output_with_timeout(command, "collect noisy output", Duration::from_secs(5))
+            .await
+            .expect("noisy command should complete");
+
+        assert!(output.status.success());
+        assert!(output.stdout.len() >= 200_000);
+        assert!(output.stderr.len() >= 200_000);
+    }
+
+    fn temporary_pid_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "computer-use-linux-command-runner-{label}-{}-{}.pid",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    async fn wait_for_pid(path: &PathBuf) -> u32 {
+        for _ in 0..100 {
+            if let Ok(value) = fs::read_to_string(path) {
+                if let Ok(pid) = value.parse() {
+                    return pid;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("child did not record its pid")
+    }
+
+    async fn wait_for_process_exit(pid: u32) {
+        for _ in 0..100 {
+            if !PathBuf::from(format!("/proc/{pid}")).exists() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        panic!("process {pid} was not killed and reaped")
+    }
+}

--- a/src/cosmic_helper.rs
+++ b/src/cosmic_helper.rs
@@ -1,12 +1,16 @@
+use crate::command_runner;
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     env,
     path::{Path, PathBuf},
-    process::Command,
+    process::Command as StdCommand,
+    time::Duration,
 };
+use tokio::process::Command;
 
 pub const COSMIC_HELPER_BINARY: &str = "computer-use-linux-cosmic";
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CosmicHelperProbe {
@@ -20,6 +24,15 @@ pub struct CosmicHelperProbe {
 pub struct CosmicHelperActivation {
     pub ok: bool,
     pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CosmicMonitor {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+    pub scale: f64,
 }
 
 pub fn resolve_helper_binary() -> Result<PathBuf> {
@@ -52,16 +65,20 @@ pub fn probe() -> Result<CosmicHelperProbe> {
     run_json_command(["probe"])
 }
 
-pub fn list_windows_json() -> Result<String> {
-    run_text_command(["list-windows"])
+pub async fn list_windows_json() -> Result<String> {
+    run_text_command_async(["list-windows"]).await
 }
 
-pub fn focused_window_json() -> Result<String> {
-    run_text_command(["focused-window"])
+pub async fn focused_window_json() -> Result<String> {
+    run_text_command_async(["focused-window"]).await
 }
 
-pub fn activate_window(window_id: u64) -> Result<CosmicHelperActivation> {
-    run_json_command(["activate-window", "--window-id", &window_id.to_string()])
+pub async fn monitor_layout() -> Result<Vec<CosmicMonitor>> {
+    run_json_command_async(["monitor-layout"]).await
+}
+
+pub async fn activate_window(window_id: u64) -> Result<CosmicHelperActivation> {
+    run_json_command_async(["activate-window", "--window-id", &window_id.to_string()]).await
 }
 
 fn run_json_command<T, I, S>(args: I) -> Result<T>
@@ -75,12 +92,23 @@ where
         .with_context(|| format!("failed to parse {COSMIC_HELPER_BINARY} JSON output"))
 }
 
-fn run_text_command<I, S>(args: I) -> Result<String>
+async fn run_json_command_async<T, I, S>(args: I) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let output = run_command_async(args).await?;
+    serde_json::from_str(&output)
+        .with_context(|| format!("failed to parse {COSMIC_HELPER_BINARY} JSON output"))
+}
+
+async fn run_text_command_async<I, S>(args: I) -> Result<String>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    run_command(args)
+    run_command_async(args).await
 }
 
 fn run_command<I, S>(args: I) -> Result<String>
@@ -93,10 +121,46 @@ where
         .into_iter()
         .map(|arg| arg.as_ref().to_string())
         .collect::<Vec<_>>();
-    let output = Command::new(&helper)
-        .args(&args)
-        .output()
-        .with_context(|| format!("failed to run {}", helper.display()))?;
+    let mut command = StdCommand::new(&helper);
+    command.args(&args);
+    let output = command_runner::output_blocking_with_timeout(
+        &mut command,
+        &format!("run {}", helper.display()),
+        PROBE_TIMEOUT,
+    )?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        bail!(
+            "{} {} failed{}",
+            helper.display(),
+            args.join(" "),
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        );
+    }
+    String::from_utf8(output.stdout)
+        .map(|text| text.trim().to_string())
+        .context("helper output was not valid UTF-8")
+}
+
+async fn run_command_async<I, S>(args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let helper = resolve_helper_binary()?;
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_string())
+        .collect::<Vec<_>>();
+    let mut command = Command::new(&helper);
+    command.args(&args);
+    let output = command_runner::output(command, &format!("run {}", helper.display())).await?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -2,16 +2,14 @@ use crate::windowing::registry::{
     self, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
     HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, X11_BACKEND,
 };
+use crate::ydotool;
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::{
     collections::{BTreeMap, HashMap},
     env, fs,
     fs::OpenOptions,
-    os::unix::{
-        fs::MetadataExt,
-        net::{UnixDatagram, UnixStream},
-    },
+    os::unix::{fs::MetadataExt, net::UnixDatagram},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -29,6 +27,11 @@ const DESKTOP_ENV_KEYS: &[&str] = &[
     "XDG_RUNTIME_DIR",
     "XDG_SESSION_TYPE",
 ];
+const FORCE_YDOTOOL_KEYBOARD_ENV_KEYS: &[&str] = &["COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD"];
+const FORCE_YDOTOOL_POINTER_ENV_KEYS: &[&str] = &["COMPUTER_USE_LINUX_FORCE_YDOTOOL_POINTER"];
+const FORCE_XDOTOOL_KEYBOARD_ENV_KEYS: &[&str] = &["COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD"];
+const FORCE_PORTAL_KEYBOARD_ENV_KEYS: &[&str] = &["COMPUTER_USE_LINUX_FORCE_PORTAL_KEYBOARD"];
+const FORCE_PORTAL_POINTER_ENV_KEYS: &[&str] = &["COMPUTER_USE_LINUX_FORCE_PORTAL_POINTER"];
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct DoctorReport {
@@ -208,14 +211,26 @@ fn capability_map(
     if input.uinput.ok {
         input_backends.push("abs_pointer".to_string());
     }
-    if portals.remote_desktop.ok {
+    let force_ydotool = env_flag_enabled_any(FORCE_YDOTOOL_KEYBOARD_ENV_KEYS);
+    let force_xdotool = env_flag_enabled_any(FORCE_XDOTOOL_KEYBOARD_ENV_KEYS);
+    let portal_available = portal_input_available(platform, portals);
+    let portal_forced_for_all_input = force_portal_for_all_input(
+        env_flag_enabled_any(FORCE_PORTAL_POINTER_ENV_KEYS),
+        env_flag_enabled_any(FORCE_PORTAL_KEYBOARD_ENV_KEYS),
+        env_flag_enabled_any(FORCE_YDOTOOL_POINTER_ENV_KEYS),
+        force_ydotool,
+    );
+    if should_advertise_xdotool(platform, input, force_ydotool, force_xdotool) {
+        input_backends.push("xdotool".to_string());
+    }
+    if portal_available && portal_forced_for_all_input {
         input_backends.push("portal".to_string());
     }
-    if input.ydotool_socket.ok {
+    if input.ydotool.ok && input.ydotool_socket.ok {
         input_backends.push("ydotool".to_string());
     }
-    if input.xdotool.ok && !session_is_wayland_env() {
-        input_backends.push("xdotool".to_string());
+    if portal_available && !portal_forced_for_all_input {
+        input_backends.push("portal".to_string());
     }
 
     let mut screenshot_backends = Vec::new();
@@ -231,20 +246,30 @@ fn capability_map(
     }
 
     let mut window_backends = Vec::new();
+    let x11_available = windowing
+        .backends
+        .get(X11_BACKEND)
+        .is_some_and(|check| check.ok);
+    let prefer_x11_over_introspect = windowing.gnome_shell_introspect.ok
+        && x11_available
+        && registry::backend_can_exact_focus(X11_BACKEND);
     if windowing.computer_use_linux_gnome_shell_extension.ok {
         window_backends.push("gnome_shell_extension".to_string());
     }
+    if prefer_x11_over_introspect {
+        window_backends.push(X11_BACKEND.to_string());
+    }
     if windowing.gnome_shell_introspect.ok {
         window_backends.push("gnome_introspect".to_string());
+    }
+    if windowing.cosmic_helper.ok {
+        window_backends.push("cosmic".to_string());
     }
     if windowing.kwin.ok {
         window_backends.push("kwin".to_string());
     }
     if windowing.hyprland.ok {
         window_backends.push("hyprland".to_string());
-    }
-    if windowing.cosmic_helper.ok {
-        window_backends.push("cosmic".to_string());
     }
     // i3 and the generic X11/EWMH backend have no dedicated WindowingReport
     // field; read them from the probe map (tried last) so the capability list
@@ -256,11 +281,7 @@ fn capability_map(
     {
         window_backends.push(I3_BACKEND.to_string());
     }
-    if windowing
-        .backends
-        .get(X11_BACKEND)
-        .is_some_and(|check| check.ok)
-    {
+    if x11_available && !prefer_x11_over_introspect {
         window_backends.push(X11_BACKEND.to_string());
     }
 
@@ -641,7 +662,10 @@ fn check_from_backend_probe(probe: &registry::BackendProbe) -> Check {
 
 fn input_report() -> InputReport {
     InputReport {
-        ydotool: command_path_check("ydotool"),
+        ydotool: match ydotool::ensure_supported() {
+            Ok(support) => Check::ok(support.detail),
+            Err(detail) => Check::fail(detail),
+        },
         ydotoold: process_check("ydotoold"),
         ydotool_socket: ydotool_socket_check(),
         uinput: read_write_path_check(Path::new("/dev/uinput")),
@@ -661,7 +685,7 @@ fn readiness_report(
     let can_query_windows = windowing.can_list_windows;
     let can_focus_apps = windowing.can_focus_apps;
     let can_focus_windows = windowing.can_focus_windows;
-    let can_send_development_input = can_send_development_input(portals, input);
+    let can_send_development_input = can_send_development_input(platform, portals, input);
 
     if !can_build_accessibility_tree {
         blockers.push(
@@ -688,7 +712,7 @@ fn readiness_report(
 
     if !can_send_development_input {
         blockers.push(
-            "Development input is unavailable; enable read/write /dev/uinput, XDG RemoteDesktop portal input, or ydotool with a connectable ydotoold socket."
+            "Development input is unavailable; enable read/write /dev/uinput, XDG RemoteDesktop portal input on Wayland, xdotool with DISPLAY on X11, or ydotool with a connectable ydotoold socket."
                 .to_string(),
         );
     }
@@ -708,7 +732,7 @@ fn readiness_report(
     } else if !can_focus_windows {
         "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
-        "Enable a supported input backend: grant read/write /dev/uinput, enable the XDG RemoteDesktop portal, or start ydotoold with a socket accessible to this desktop user."
+        "Enable a supported input backend: grant read/write /dev/uinput, enable the XDG RemoteDesktop portal on Wayland, install xdotool for X11, or start ydotoold with a socket accessible to this desktop user."
             .to_string()
     } else {
         "Computer Use is ready: AT-SPI tree support, window targeting, and a Linux input backend are available."
@@ -727,10 +751,21 @@ fn readiness_report(
     }
 }
 
-fn can_send_development_input(portals: &PortalReport, input: &InputReport) -> bool {
+fn can_send_development_input(
+    platform: &PlatformReport,
+    portals: &PortalReport,
+    input: &InputReport,
+) -> bool {
+    let force_ydotool = env_flag_enabled_any(FORCE_YDOTOOL_KEYBOARD_ENV_KEYS);
+    let force_xdotool = env_flag_enabled_any(FORCE_XDOTOOL_KEYBOARD_ENV_KEYS);
     input.uinput.ok
-        || portals.remote_desktop.ok
-        || input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok
+        || portal_input_available(platform, portals)
+        || should_advertise_xdotool(platform, input, force_ydotool, force_xdotool)
+        || input.ydotool.ok && input.ydotool_socket.ok
+}
+
+fn portal_input_available(platform: &PlatformReport, portals: &PortalReport) -> bool {
+    platform_is_wayland(platform) && portals.remote_desktop.ok
 }
 
 fn is_cosmic_wayland_platform(platform: &PlatformReport) -> bool {
@@ -816,15 +851,46 @@ fn command_path_check(command: &str) -> Check {
     command_check("sh", &["-c", &format!("command -v {command}")])
 }
 
-/// True when this looks like a Wayland session. Used to avoid advertising the
-/// X11-only `xdotool` backend on Wayland, where XTEST does not reach clients.
-fn session_is_wayland_env() -> bool {
-    match std::env::var("XDG_SESSION_TYPE") {
-        Ok(value) => value.eq_ignore_ascii_case("wayland"),
-        Err(_) => std::env::var("WAYLAND_DISPLAY")
-            .map(|value| !value.trim().is_empty())
-            .unwrap_or(false),
+fn platform_is_wayland(platform: &PlatformReport) -> bool {
+    match platform.xdg_session_type.as_deref() {
+        Some(value) => value.eq_ignore_ascii_case("wayland"),
+        None => platform
+            .wayland_display
+            .as_deref()
+            .is_some_and(|display| !display.trim().is_empty()),
     }
+}
+
+fn should_advertise_xdotool(
+    platform: &PlatformReport,
+    input: &InputReport,
+    force_ydotool: bool,
+    force_xdotool: bool,
+) -> bool {
+    !force_ydotool
+        && input.xdotool.ok
+        && platform
+            .display
+            .as_deref()
+            .is_some_and(|display| !display.trim().is_empty())
+        && (force_xdotool || !platform_is_wayland(platform))
+}
+
+fn env_flag_enabled_any(keys: &[&str]) -> bool {
+    keys.iter()
+        .any(|key| env::var(key).ok().as_deref() == Some("1"))
+}
+
+fn force_portal_for_all_input(
+    force_portal_pointer: bool,
+    force_portal_keyboard: bool,
+    force_ydotool_pointer: bool,
+    force_ydotool_keyboard: bool,
+) -> bool {
+    force_portal_pointer
+        && force_portal_keyboard
+        && !force_ydotool_pointer
+        && !force_ydotool_keyboard
 }
 
 fn process_check(process_name: &str) -> Check {
@@ -844,20 +910,9 @@ fn socket_connect_result(path: &Path) -> std::result::Result<(), String> {
         return Err(format!("missing: {}", path.display()));
     }
 
-    match UnixStream::connect(path) {
-        Ok(_) => Ok(()),
-        Err(stream_error) => {
-            match UnixDatagram::unbound().and_then(|socket| socket.connect(path)) {
-                Ok(()) => Ok(()),
-                Err(datagram_error) => Err(format!(
-                    "{}: stream: {}; datagram: {}",
-                    path.display(),
-                    stream_error,
-                    datagram_error
-                )),
-            }
-        }
-    }
+    UnixDatagram::unbound()
+        .and_then(|socket| socket.connect(path))
+        .map_err(|error| format!("{}: datagram: {error}", path.display()))
 }
 
 fn read_write_path_check(path: &Path) -> Check {
@@ -1144,6 +1199,117 @@ mod tests {
     }
 
     #[test]
+    fn capabilities_prefer_xdotool_before_ydotool_on_x11() {
+        let mut platform = platform_report();
+        platform.xdg_session_type = Some("x11".to_string());
+        platform.wayland_display = None;
+        platform.display = Some(":0".to_string());
+        let input = InputReport {
+            ydotool: Check::ok("ydotool"),
+            ydotoold: Check::ok("ydotoold"),
+            ydotool_socket: Check::ok("connectable"),
+            uinput: Check::fail("missing"),
+            xdotool: Check::ok("xdotool"),
+        };
+
+        let capabilities = capability_map(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility_report(Check::fail("missing"), Check::fail("missing")),
+            &windowing_report(false, false),
+            &input,
+        );
+
+        assert_eq!(capabilities.input, ["xdotool", "ydotool"]);
+        assert_eq!(capabilities.preferred.input.as_deref(), Some("xdotool"));
+    }
+
+    #[test]
+    fn x11_diagnostics_ignore_portal_and_accept_xdotool() {
+        let mut platform = platform_report();
+        platform.xdg_session_type = Some("x11".to_string());
+        platform.wayland_display = None;
+        platform.display = Some(":0".to_string());
+        let portals = portal_report(Check::ok("org.freedesktop.portal.RemoteDesktop"));
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let mut input = input_report(false);
+        input.xdotool = Check::ok("xdotool");
+
+        let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &portals, &accessibility, &windowing, &input);
+
+        assert_eq!(capabilities.input, ["xdotool"]);
+        assert_eq!(capabilities.preferred.input.as_deref(), Some("xdotool"));
+        assert!(readiness.can_send_development_input);
+    }
+
+    #[test]
+    fn wayland_diagnostics_prefer_ydotool_before_portal() {
+        let platform = platform_report();
+        let portals = portal_report(Check::ok("org.freedesktop.portal.RemoteDesktop"));
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::ok("ydotool"),
+            Check::ok("ydotoold"),
+            Check::ok("connectable"),
+            Check::fail("missing uinput"),
+        );
+
+        let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+
+        assert_eq!(capabilities.input, ["ydotool", "portal"]);
+        assert_eq!(capabilities.preferred.input.as_deref(), Some("ydotool"));
+    }
+
+    #[test]
+    fn portal_force_order_requires_both_input_modalities() {
+        assert!(force_portal_for_all_input(true, true, false, false));
+        assert!(!force_portal_for_all_input(true, false, false, false));
+        assert!(!force_portal_for_all_input(true, true, true, false));
+        assert!(!force_portal_for_all_input(true, true, false, true));
+    }
+
+    #[test]
+    fn capabilities_require_display_to_advertise_xdotool() {
+        let mut platform = platform_report();
+        platform.xdg_session_type = Some("x11".to_string());
+        platform.wayland_display = None;
+        platform.display = None;
+        let input = InputReport {
+            ydotool: Check::ok("ydotool"),
+            ydotoold: Check::ok("ydotoold"),
+            ydotool_socket: Check::ok("connectable"),
+            uinput: Check::fail("missing"),
+            xdotool: Check::ok("xdotool"),
+        };
+
+        let capabilities = capability_map(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility_report(Check::fail("missing"), Check::fail("missing")),
+            &windowing_report(false, false),
+            &input,
+        );
+
+        assert_eq!(capabilities.input, ["ydotool"]);
+        assert_eq!(capabilities.preferred.input.as_deref(), Some("ydotool"));
+    }
+
+    #[test]
+    fn xdotool_diagnostics_force_precedence_matches_runtime() {
+        let mut platform = platform_report();
+        platform.xdg_session_type = Some("wayland".to_string());
+        platform.display = Some(":0".to_string());
+        let mut input = input_report(false);
+        input.xdotool = Check::ok("xdotool");
+
+        assert!(should_advertise_xdotool(&platform, &input, false, true));
+        assert!(!should_advertise_xdotool(&platform, &input, true, true));
+    }
+
+    #[test]
     fn parses_systemd_show_environment_output() {
         let environment = parse_line_environment(
             b"DISPLAY=:0\nHYPRLAND_INSTANCE_SIGNATURE=abc\nNO_EQUALS\nYDOTOOL_SOCKET=/run/ydotoold/socket\n",
@@ -1264,6 +1430,29 @@ mod tests {
     }
 
     #[test]
+    fn readiness_uses_connectable_ydotool_socket_when_process_probe_fails() {
+        let platform = platform_report();
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::ok("ydotool"),
+            Check::fail("ydotoold process name not found"),
+            Check::ok("connectable: /run/user/1000/.ydotool_socket"),
+            Check::fail("/dev/uinput: Permission denied"),
+        );
+        let portals = portal_report(Check::fail("missing"));
+
+        let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &portals, &accessibility, &windowing, &input);
+
+        assert!(capabilities
+            .input
+            .iter()
+            .any(|backend| backend == "ydotool"));
+        assert!(readiness.can_send_development_input);
+    }
+
+    #[test]
     fn readiness_accepts_direct_uinput_without_connectable_ydotool_socket() {
         let platform = platform_report();
         let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
@@ -1342,7 +1531,30 @@ mod tests {
     }
 
     #[test]
-    fn ydotool_socket_check_requires_a_connectable_socket() {
+    fn capability_map_rejects_incompatible_ydotool_with_live_daemon() {
+        let platform = platform_report();
+        let portals = portal_report(Check::fail("missing"));
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::fail("unsupported legacy ydotool CLI"),
+            Check::ok("ydotoold"),
+            Check::ok("connectable socket"),
+            Check::fail("/dev/uinput: Permission denied"),
+        );
+
+        let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &portals, &accessibility, &windowing, &input);
+
+        assert!(!capabilities
+            .input
+            .iter()
+            .any(|backend| backend == "ydotool"));
+        assert!(!readiness.can_send_development_input);
+    }
+
+    #[test]
+    fn ydotool_socket_check_rejects_legacy_stream_socket() {
         let dir = std::env::temp_dir().join(format!(
             "computer-use-linux-diagnostics-{}",
             std::process::id()
@@ -1355,7 +1567,7 @@ mod tests {
 
         let check = socket_connect_check(&socket);
 
-        assert!(check.ok, "{check:?}");
+        assert!(!check.ok, "{check:?}");
         drop(listener);
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod abs_pointer;
 #[path = "atspi_tree.rs"]
 mod atspi_tree_impl;
 mod cli;
+mod command_runner;
 mod cosmic_helper;
 #[path = "diagnostics.rs"]
 mod diagnostics_impl;
@@ -14,6 +15,7 @@ mod server;
 mod terminal;
 mod windowing;
 mod windows;
+mod ydotool;
 
 pub mod atspi_tree {
     pub(crate) use crate::atspi_tree_impl::{

--- a/src/remote_desktop.rs
+++ b/src/remote_desktop.rs
@@ -1,7 +1,16 @@
-use crate::diagnostics::hydrate_session_bus_env;
+use crate::{command_runner, diagnostics::hydrate_session_bus_env};
 use anyhow::{bail, Context, Result};
 use futures_util::StreamExt;
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock,
+    },
+    time::Duration,
+};
+use tokio::process::Command;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 use xkeysym::Keysym;
 use zbus::{
     proxy::SignalStream,
@@ -14,7 +23,11 @@ const PORTAL_DESKTOP_PATH: &str = "/org/freedesktop/portal/desktop";
 const PORTAL_REMOTE_DESKTOP_INTERFACE: &str = "org.freedesktop.portal.RemoteDesktop";
 const PORTAL_SCREENCAST_INTERFACE: &str = "org.freedesktop.portal.ScreenCast";
 const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
+const PORTAL_SESSION_INTERFACE: &str = "org.freedesktop.portal.Session";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const PORTAL_CALL_TIMEOUT: Duration = Duration::from_secs(5);
+const RELEASE_TIMEOUT: Duration = Duration::from_secs(1);
+const INPUT_TIMEOUT: Duration = Duration::from_secs(3);
 
 const DEVICE_KEYBOARD: u32 = 1;
 const DEVICE_POINTER: u32 = 2;
@@ -43,12 +56,17 @@ pub struct PortalPointerSession {
     connection: Connection,
     session_handle: OwnedObjectPath,
     streams: Vec<PortalStream>,
+    desktop_layout: Option<Vec<LogicalMonitor>>,
+    input_lock: Arc<AsyncMutex<()>>,
+    valid: Arc<AtomicBool>,
 }
 
 #[derive(Clone)]
 pub struct PortalKeyboardSession {
     connection: Connection,
     session_handle: OwnedObjectPath,
+    input_lock: Arc<AsyncMutex<()>>,
+    valid: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +74,43 @@ struct PortalStream {
     node_id: u32,
     position: Option<(i32, i32)>,
     size: Option<(i32, i32)>,
+}
+
+#[derive(Debug, Clone)]
+struct LogicalMonitor {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    scale: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PressedKey {
+    Keysym(i32),
+    Keycode(i32),
+}
+
+struct PointerReleaseGuard {
+    connection: Connection,
+    session_handle: OwnedObjectPath,
+    button: Option<i32>,
+    input_guard: Option<OwnedMutexGuard<()>>,
+    valid: Arc<AtomicBool>,
+}
+
+struct KeyboardReleaseGuard {
+    connection: Connection,
+    session_handle: OwnedObjectPath,
+    pressed: Vec<PressedKey>,
+    input_guard: Option<OwnedMutexGuard<()>>,
+    valid: Arc<AtomicBool>,
+}
+
+struct PortalSessionCleanup {
+    connection: Connection,
+    session_handle: OwnedObjectPath,
+    armed: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -84,6 +139,7 @@ pub async fn start_portal_pointer_session() -> Result<PortalPointerSession> {
         .await
         .context("failed to connect to session bus for remote desktop portal")?;
     let session_handle = create_remote_desktop_session(&connection).await?;
+    let mut cleanup = PortalSessionCleanup::new(connection.clone(), session_handle.clone());
     select_pointer_devices(&connection, &session_handle).await?;
     select_monitor_sources(&connection, &session_handle).await?;
     let (devices, streams) = start_remote_desktop_session(&connection, &session_handle).await?;
@@ -95,10 +151,16 @@ pub async fn start_portal_pointer_session() -> Result<PortalPointerSession> {
         bail!("remote desktop portal session started without any monitor streams");
     }
 
+    let desktop_layout = logical_desktop_layout().await;
+    cleanup.disarm();
+
     Ok(PortalPointerSession {
         connection,
         session_handle,
         streams,
+        desktop_layout,
+        input_lock: portal_input_lock(),
+        valid: Arc::new(AtomicBool::new(true)),
     })
 }
 
@@ -109,16 +171,302 @@ pub async fn start_portal_keyboard_session() -> Result<PortalKeyboardSession> {
         .await
         .context("failed to connect to session bus for remote desktop portal")?;
     let session_handle = create_remote_desktop_session(&connection).await?;
+    let mut cleanup = PortalSessionCleanup::new(connection.clone(), session_handle.clone());
     select_keyboard_devices(&connection, &session_handle).await?;
     let (devices, _) = start_remote_desktop_session(&connection, &session_handle).await?;
 
     if devices & DEVICE_KEYBOARD == 0 {
         bail!("remote desktop portal session started without keyboard access");
     }
+    cleanup.disarm();
 
     Ok(PortalKeyboardSession {
         connection,
         session_handle,
+        input_lock: portal_input_lock(),
+        valid: Arc::new(AtomicBool::new(true)),
+    })
+}
+
+fn portal_input_lock() -> Arc<AsyncMutex<()>> {
+    static INPUT_LOCK: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    Arc::clone(INPUT_LOCK.get_or_init(|| Arc::new(AsyncMutex::new(()))))
+}
+
+async fn logical_desktop_layout() -> Option<Vec<LogicalMonitor>> {
+    if env_token_contains("XDG_CURRENT_DESKTOP", "gnome") {
+        if let Some(layout) = crate::windowing::backends::gnome::extension_monitor_layout()
+            .await
+            .ok()
+            .filter(|monitors| !monitors.is_empty())
+            .map(|monitors| {
+                monitors
+                    .into_iter()
+                    .map(|monitor| LogicalMonitor {
+                        x: monitor.x,
+                        y: monitor.y,
+                        width: monitor.width,
+                        height: monitor.height,
+                        scale: monitor.scale,
+                    })
+                    .collect::<Vec<_>>()
+            })
+        {
+            if layout.iter().all(|monitor| {
+                monitor.width > 0
+                    && monitor.height > 0
+                    && monitor.scale.is_finite()
+                    && monitor.scale >= 0.0
+            }) {
+                return Some(layout);
+            }
+        }
+    }
+
+    if env_token_contains("XDG_CURRENT_DESKTOP", "hyprland") {
+        let mut command = Command::new("hyprctl");
+        command.args(["monitors", "-j"]);
+        if let Ok(output) = command_runner::output(command, "query Hyprland monitor layout").await {
+            if output.status.success() {
+                if let Some(layout) = parse_hyprland_monitor_layout(&output.stdout) {
+                    return Some(layout);
+                }
+            }
+        }
+    }
+
+    if env_token_contains("XDG_CURRENT_DESKTOP", "kde")
+        || env_token_contains("XDG_CURRENT_DESKTOP", "plasma")
+    {
+        let mut command = Command::new("kscreen-doctor");
+        command.arg("-j");
+        if let Ok(output) = command_runner::output(command, "query KDE monitor layout").await {
+            if output.status.success() {
+                if let Some(layout) = parse_kscreen_monitor_layout(&output.stdout) {
+                    return Some(layout);
+                }
+            }
+        }
+    }
+
+    if env_token_contains("XDG_CURRENT_DESKTOP", "sway") || std::env::var_os("SWAYSOCK").is_some() {
+        let mut command = Command::new("swaymsg");
+        command.args(["-t", "get_outputs", "-r"]);
+        if let Ok(output) = command_runner::output(command, "query Sway output layout").await {
+            if output.status.success() {
+                if let Some(layout) = parse_sway_monitor_layout(&output.stdout) {
+                    return Some(layout);
+                }
+            }
+        }
+    }
+
+    if env_token_contains("XDG_CURRENT_DESKTOP", "cosmic") {
+        if let Ok(monitors) = crate::cosmic_helper::monitor_layout().await {
+            let layout = monitors
+                .into_iter()
+                .map(|monitor| LogicalMonitor {
+                    x: monitor.x,
+                    y: monitor.y,
+                    width: monitor.width,
+                    height: monitor.height,
+                    scale: monitor.scale,
+                })
+                .collect::<Vec<_>>();
+            if !layout.is_empty()
+                && layout.iter().all(|monitor| {
+                    monitor.width > 0
+                        && monitor.height > 0
+                        && monitor.scale.is_finite()
+                        && monitor.scale > 0.0
+                })
+            {
+                return Some(layout);
+            }
+        }
+    }
+
+    let mut command = Command::new("xrandr");
+    command.arg("--listactivemonitors");
+    let output = command_runner::output(command, "query XRandR monitor layout")
+        .await
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| parse_xrandr_monitor_layout(&String::from_utf8_lossy(&output.stdout)))
+        .flatten()
+}
+
+#[derive(serde::Deserialize)]
+struct HyprlandMonitorLayout {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+    scale: f64,
+    #[serde(default)]
+    transform: i32,
+}
+
+fn parse_hyprland_monitor_layout(json: &[u8]) -> Option<Vec<LogicalMonitor>> {
+    let monitors: Vec<HyprlandMonitorLayout> = serde_json::from_slice(json).ok()?;
+    let layout = monitors
+        .into_iter()
+        .map(|monitor| {
+            if !monitor.scale.is_finite()
+                || monitor.scale <= 0.0
+                || monitor.width <= 0
+                || monitor.height <= 0
+            {
+                return None;
+            }
+            let (width, height) = if monitor.transform.rem_euclid(2) == 1 {
+                (monitor.height, monitor.width)
+            } else {
+                (monitor.width, monitor.height)
+            };
+            let width = (f64::from(width) / monitor.scale).round() as i32;
+            let height = (f64::from(height) / monitor.scale).round() as i32;
+            (width > 0 && height > 0).then_some(LogicalMonitor {
+                x: monitor.x,
+                y: monitor.y,
+                width,
+                height,
+                scale: monitor.scale,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    (!layout.is_empty()).then_some(layout)
+}
+
+#[derive(serde::Deserialize)]
+struct KscreenConfig {
+    outputs: Vec<KscreenOutput>,
+}
+
+#[derive(serde::Deserialize)]
+struct KscreenOutput {
+    pos: KscreenPoint,
+    size: KscreenSize,
+    scale: f64,
+    connected: bool,
+    enabled: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct KscreenPoint {
+    x: i32,
+    y: i32,
+}
+
+#[derive(serde::Deserialize)]
+struct KscreenSize {
+    width: i32,
+    height: i32,
+}
+
+fn parse_kscreen_monitor_layout(json: &[u8]) -> Option<Vec<LogicalMonitor>> {
+    let config: KscreenConfig = serde_json::from_slice(json).ok()?;
+    let layout = config
+        .outputs
+        .into_iter()
+        .filter(|output| output.connected && output.enabled)
+        .map(|output| {
+            if !output.scale.is_finite()
+                || output.scale <= 0.0
+                || output.size.width <= 0
+                || output.size.height <= 0
+            {
+                return None;
+            }
+            let width = (f64::from(output.size.width) / output.scale).round() as i32;
+            let height = (f64::from(output.size.height) / output.scale).round() as i32;
+            (width > 0 && height > 0).then_some(LogicalMonitor {
+                x: output.pos.x,
+                y: output.pos.y,
+                width,
+                height,
+                scale: output.scale,
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    (!layout.is_empty()).then_some(layout)
+}
+
+#[derive(serde::Deserialize)]
+struct SwayOutput {
+    active: bool,
+    rect: SwayRect,
+    scale: f64,
+}
+
+#[derive(serde::Deserialize)]
+struct SwayRect {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+}
+
+fn parse_sway_monitor_layout(json: &[u8]) -> Option<Vec<LogicalMonitor>> {
+    let outputs: Vec<SwayOutput> = serde_json::from_slice(json).ok()?;
+    let layout = outputs
+        .into_iter()
+        .filter(|output| output.active)
+        .map(|output| {
+            (output.scale.is_finite()
+                && output.scale > 0.0
+                && output.rect.width > 0
+                && output.rect.height > 0)
+                .then_some(LogicalMonitor {
+                    x: output.rect.x,
+                    y: output.rect.y,
+                    width: output.rect.width,
+                    height: output.rect.height,
+                    scale: output.scale,
+                })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    (!layout.is_empty()).then_some(layout)
+}
+
+fn parse_xrandr_monitor_layout(output: &str) -> Option<Vec<LogicalMonitor>> {
+    let mut lines = output.lines();
+    let monitor_count = lines
+        .next()?
+        .strip_prefix("Monitors:")?
+        .trim()
+        .parse::<usize>()
+        .ok()?;
+    let layout = lines
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            line.split_whitespace()
+                .find_map(parse_xrandr_monitor_geometry)
+        })
+        .collect::<Option<Vec<_>>>()?;
+    (monitor_count > 0 && layout.len() == monitor_count).then_some(layout)
+}
+
+fn parse_xrandr_monitor_geometry(value: &str) -> Option<LogicalMonitor> {
+    let (width, rest) = value.split_once('/')?;
+    let (_, rest) = rest.split_once('x')?;
+    let (height, rest) = rest.split_once('/')?;
+    let offset_start = rest.find(['+', '-'])?;
+    let offsets = &rest[offset_start..];
+    let second_sign = offsets[1..].find(['+', '-'])? + 1;
+    let (x, y) = offsets.split_at(second_sign);
+    let width = width.parse().ok()?;
+    let height = height.parse().ok()?;
+    let x = x.parse().ok()?;
+    let y = y.parse().ok()?;
+    (width > 0 && height > 0).then_some(LogicalMonitor {
+        x,
+        y,
+        width,
+        height,
+        scale: 0.0,
     })
 }
 
@@ -144,10 +492,14 @@ pub async fn click(
     button: PointerButton,
     click_count: u32,
 ) -> Result<()> {
+    let input_guard = Arc::clone(&session.input_lock).lock_owned().await;
+    session.ensure_current_layout().await?;
     let proxy = remote_desktop_proxy(&session.connection).await?;
+    let mut release_guard = PointerReleaseGuard::new(session, input_guard);
     let (stream_id, x, y) = session.map_absolute_point(x, y)?;
     notify_pointer_motion_absolute(&proxy, &session.session_handle, stream_id, x, y).await?;
     for _ in 0..click_count.max(1) {
+        release_guard.arm(button.evdev_code());
         notify_pointer_button(
             &proxy,
             &session.session_handle,
@@ -163,6 +515,7 @@ pub async fn click(
             POINTER_BUTTON_RELEASED,
         )
         .await?;
+        release_guard.disarm();
     }
     Ok(())
 }
@@ -173,6 +526,12 @@ pub async fn scroll(
     direction: ScrollDirection,
     steps: i32,
 ) -> Result<()> {
+    let _input_guard = Arc::clone(&session.input_lock).lock_owned().await;
+    if target_point.is_some() {
+        session.ensure_current_layout().await?;
+    } else {
+        session.ensure_valid()?;
+    }
     let proxy = remote_desktop_proxy(&session.connection).await?;
     if let Some((x, y)) = target_point {
         let (stream_id, x, y) = session.map_absolute_point(x, y)?;
@@ -272,8 +631,12 @@ pub async fn drag(
     end_x: i32,
     end_y: i32,
 ) -> Result<()> {
+    let input_guard = Arc::clone(&session.input_lock).lock_owned().await;
+    session.ensure_current_layout().await?;
     let proxy = remote_desktop_proxy(&session.connection).await?;
+    let mut release_guard = PointerReleaseGuard::new(session, input_guard);
     let (start_stream, start_x, start_y) = session.map_absolute_point(start_x, start_y)?;
+    let (end_stream, end_x, end_y) = session.map_absolute_point(end_x, end_y)?;
     notify_pointer_motion_absolute(
         &proxy,
         &session.session_handle,
@@ -282,6 +645,7 @@ pub async fn drag(
         start_y,
     )
     .await?;
+    release_guard.arm(BTN_LEFT);
     notify_pointer_button(
         &proxy,
         &session.session_handle,
@@ -290,7 +654,6 @@ pub async fn drag(
     )
     .await?;
     tokio::time::sleep(Duration::from_millis(35)).await;
-    let (end_stream, end_x, end_y) = session.map_absolute_point(end_x, end_y)?;
     notify_pointer_motion_absolute(&proxy, &session.session_handle, end_stream, end_x, end_y)
         .await?;
     tokio::time::sleep(Duration::from_millis(35)).await;
@@ -300,18 +663,25 @@ pub async fn drag(
         BTN_LEFT,
         POINTER_BUTTON_RELEASED,
     )
-    .await
+    .await?;
+    release_guard.disarm();
+    Ok(())
 }
 
 pub async fn type_text_with_keysyms(
     session: &PortalKeyboardSession,
     keysyms: &[i32],
 ) -> Result<()> {
+    let input_guard = Arc::clone(&session.input_lock).lock_owned().await;
+    session.ensure_valid()?;
     let proxy = remote_desktop_proxy(&session.connection).await?;
+    let mut release_guard = KeyboardReleaseGuard::new(session, input_guard);
     for keysym in keysyms {
+        release_guard.push(PressedKey::Keysym(*keysym));
         notify_keyboard_keysym(&proxy, &session.session_handle, *keysym, KEY_PRESSED).await?;
         tokio::time::sleep(Duration::from_millis(5)).await;
         notify_keyboard_keysym(&proxy, &session.session_handle, *keysym, KEY_RELEASED).await?;
+        release_guard.pop();
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
     Ok(())
@@ -322,20 +692,236 @@ pub async fn press_keycode_chord(
     modifiers: &[i32],
     keycode: i32,
 ) -> Result<()> {
+    let input_guard = Arc::clone(&session.input_lock).lock_owned().await;
+    session.ensure_valid()?;
     let proxy = remote_desktop_proxy(&session.connection).await?;
+    let mut release_guard = KeyboardReleaseGuard::new(session, input_guard);
     for modifier in modifiers {
+        release_guard.push(PressedKey::Keycode(*modifier));
         notify_keyboard_keycode(&proxy, &session.session_handle, *modifier, KEY_PRESSED).await?;
     }
+    release_guard.push(PressedKey::Keycode(keycode));
     notify_keyboard_keycode(&proxy, &session.session_handle, keycode, KEY_PRESSED).await?;
     tokio::time::sleep(Duration::from_millis(35)).await;
     notify_keyboard_keycode(&proxy, &session.session_handle, keycode, KEY_RELEASED).await?;
+    release_guard.pop();
     for modifier in modifiers.iter().rev() {
         notify_keyboard_keycode(&proxy, &session.session_handle, *modifier, KEY_RELEASED).await?;
+        release_guard.pop();
     }
     Ok(())
 }
 
+impl PointerReleaseGuard {
+    fn new(session: &PortalPointerSession, input_guard: OwnedMutexGuard<()>) -> Self {
+        Self {
+            connection: session.connection.clone(),
+            session_handle: session.session_handle.clone(),
+            button: None,
+            input_guard: Some(input_guard),
+            valid: Arc::clone(&session.valid),
+        }
+    }
+
+    fn arm(&mut self, button: i32) {
+        self.button = Some(button);
+    }
+
+    fn disarm(&mut self) {
+        self.button = None;
+    }
+}
+
+impl Drop for PointerReleaseGuard {
+    fn drop(&mut self) {
+        let input_guard = self.input_guard.take();
+        let Some(button) = self.button else {
+            return;
+        };
+        self.valid.store(false, Ordering::Release);
+        let connection = self.connection.clone();
+        let session_handle = self.session_handle.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = tokio::time::timeout(RELEASE_TIMEOUT, async {
+                    if let Ok(proxy) = remote_desktop_proxy(&connection).await {
+                        let _ = notify_pointer_button(
+                            &proxy,
+                            &session_handle,
+                            button,
+                            POINTER_BUTTON_RELEASED,
+                        )
+                        .await;
+                    }
+                })
+                .await;
+                let _ = tokio::time::timeout(
+                    RELEASE_TIMEOUT,
+                    close_portal_session(&connection, &session_handle),
+                )
+                .await;
+                drop(input_guard);
+            });
+        }
+    }
+}
+
+impl KeyboardReleaseGuard {
+    fn new(session: &PortalKeyboardSession, input_guard: OwnedMutexGuard<()>) -> Self {
+        Self {
+            connection: session.connection.clone(),
+            session_handle: session.session_handle.clone(),
+            pressed: Vec::new(),
+            input_guard: Some(input_guard),
+            valid: Arc::clone(&session.valid),
+        }
+    }
+
+    fn push(&mut self, key: PressedKey) {
+        self.pressed.push(key);
+    }
+
+    fn pop(&mut self) {
+        self.pressed.pop();
+    }
+}
+
+impl PortalSessionCleanup {
+    fn new(connection: Connection, session_handle: OwnedObjectPath) -> Self {
+        Self {
+            connection,
+            session_handle,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PortalSessionCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let connection = self.connection.clone();
+        let session_handle = self.session_handle.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = tokio::time::timeout(
+                    RELEASE_TIMEOUT,
+                    close_portal_session(&connection, &session_handle),
+                )
+                .await;
+            });
+        }
+    }
+}
+
+impl Drop for KeyboardReleaseGuard {
+    fn drop(&mut self) {
+        let input_guard = self.input_guard.take();
+        if self.pressed.is_empty() {
+            return;
+        }
+        self.valid.store(false, Ordering::Release);
+        let connection = self.connection.clone();
+        let session_handle = self.session_handle.clone();
+        let pressed = std::mem::take(&mut self.pressed);
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = tokio::time::timeout(RELEASE_TIMEOUT, async {
+                    if let Ok(proxy) = remote_desktop_proxy(&connection).await {
+                        for key in pressed.into_iter().rev() {
+                            match key {
+                                PressedKey::Keysym(keysym) => {
+                                    let _ = notify_keyboard_keysym(
+                                        &proxy,
+                                        &session_handle,
+                                        keysym,
+                                        KEY_RELEASED,
+                                    )
+                                    .await;
+                                }
+                                PressedKey::Keycode(keycode) => {
+                                    let _ = notify_keyboard_keycode(
+                                        &proxy,
+                                        &session_handle,
+                                        keycode,
+                                        KEY_RELEASED,
+                                    )
+                                    .await;
+                                }
+                            }
+                        }
+                    }
+                })
+                .await;
+                let _ = tokio::time::timeout(
+                    RELEASE_TIMEOUT,
+                    close_portal_session(&connection, &session_handle),
+                )
+                .await;
+                drop(input_guard);
+            });
+        }
+    }
+}
+
 impl PortalPointerSession {
+    pub(crate) fn is_valid(&self) -> bool {
+        self.valid.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn invalidate_and_close(&self) {
+        invalidate_and_close(&self.valid, &self.connection, &self.session_handle);
+    }
+
+    pub(crate) fn same_session(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.valid, &other.valid)
+    }
+
+    fn ensure_valid(&self) -> Result<()> {
+        if !self.is_valid() {
+            bail!("remote desktop portal pointer session is no longer valid");
+        }
+        Ok(())
+    }
+
+    async fn ensure_current_layout(&self) -> Result<()> {
+        self.ensure_valid()?;
+        let expected = self
+            .desktop_layout
+            .as_deref()
+            .context("remote desktop portal session has no authoritative monitor layout")?;
+        let current = logical_desktop_layout()
+            .await
+            .context("could not revalidate the current monitor layout")?;
+        if !same_monitor_layout(expected, &current) {
+            self.invalidate_and_close();
+            bail!("desktop monitor layout changed after the remote desktop portal session started");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn logical_point_from_capture(
+        &self,
+        x: i32,
+        y: i32,
+        capture_size: Option<(u32, u32)>,
+    ) -> Option<(i32, i32)> {
+        let (width, height) = capture_size?;
+        map_capture_point_to_stream_layout(
+            &self.streams,
+            self.desktop_layout.as_deref()?,
+            x,
+            y,
+            width,
+            height,
+        )
+    }
+
     fn map_absolute_point(&self, x: i32, y: i32) -> Result<(u32, f64, f64)> {
         if let Some(stream) = self
             .streams
@@ -345,11 +931,149 @@ impl PortalPointerSession {
             return Ok(stream.relative_point(x, y));
         }
 
-        self.streams
-            .first()
-            .map(|stream| stream.relative_point(x, y))
-            .context("remote desktop portal session had no usable streams")
+        bail!("point ({x}, {y}) is outside the monitors shared with the remote desktop portal")
     }
+}
+
+impl PortalKeyboardSession {
+    pub(crate) fn is_valid(&self) -> bool {
+        self.valid.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn invalidate_and_close(&self) {
+        invalidate_and_close(&self.valid, &self.connection, &self.session_handle);
+    }
+
+    pub(crate) fn same_session(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.valid, &other.valid)
+    }
+
+    fn ensure_valid(&self) -> Result<()> {
+        if !self.is_valid() {
+            bail!("remote desktop portal keyboard session is no longer valid");
+        }
+        Ok(())
+    }
+}
+
+fn same_monitor_layout(expected: &[LogicalMonitor], current: &[LogicalMonitor]) -> bool {
+    if expected.len() != current.len() {
+        return false;
+    }
+    let mut expected = expected.to_vec();
+    let mut current = current.to_vec();
+    let sort_key = |monitor: &LogicalMonitor| (monitor.x, monitor.y, monitor.width, monitor.height);
+    expected.sort_by_key(sort_key);
+    current.sort_by_key(sort_key);
+    expected.iter().zip(current.iter()).all(|(left, right)| {
+        sort_key(left) == sort_key(right) && (left.scale - right.scale).abs() <= 0.01
+    })
+}
+
+fn map_capture_point_to_stream_layout(
+    streams: &[PortalStream],
+    desktop_layout: &[LogicalMonitor],
+    x: i32,
+    y: i32,
+    capture_width: u32,
+    capture_height: u32,
+) -> Option<(i32, i32)> {
+    if capture_width == 0
+        || capture_height == 0
+        || x < 0
+        || y < 0
+        || x >= i32::try_from(capture_width).unwrap_or(i32::MAX)
+        || y >= i32::try_from(capture_height).unwrap_or(i32::MAX)
+    {
+        return None;
+    }
+
+    let mut stream_rects = streams
+        .iter()
+        .map(|stream| {
+            let (x, y) = stream.position?;
+            let (width, height) = stream.size?;
+            (width > 0 && height > 0).then_some((x, y, width, height))
+        })
+        .collect::<Option<Vec<_>>>()?;
+    if desktop_layout.is_empty()
+        || desktop_layout
+            .iter()
+            .any(|monitor| monitor.width <= 0 || monitor.height <= 0)
+    {
+        return None;
+    }
+    let mut monitor_rects = desktop_layout
+        .iter()
+        .map(|monitor| (monitor.x, monitor.y, monitor.width, monitor.height))
+        .collect::<Vec<_>>();
+    stream_rects.sort_unstable();
+    monitor_rects.sort_unstable();
+    if stream_rects != monitor_rects {
+        return None;
+    }
+
+    let unknown_multi_monitor_scale = desktop_layout.len() > 1
+        && desktop_layout
+            .iter()
+            .any(|monitor| !monitor.scale.is_finite() || monitor.scale <= 0.0);
+    if desktop_layout.len() > 1 && !unknown_multi_monitor_scale {
+        let first_scale = desktop_layout.first()?.scale;
+        if desktop_layout
+            .iter()
+            .any(|monitor| (monitor.scale - first_scale).abs() > 0.01)
+        {
+            return None;
+        }
+    }
+
+    let mut bounds = monitor_rects.iter().map(|(x, y, width, height)| {
+        (
+            i64::from(*x),
+            i64::from(*y),
+            i64::from(*x) + i64::from(*width),
+            i64::from(*y) + i64::from(*height),
+        )
+    });
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = bounds.next()?;
+    for (left, top, right, bottom) in bounds {
+        min_x = min_x.min(left);
+        min_y = min_y.min(top);
+        max_x = max_x.max(right);
+        max_y = max_y.max(bottom);
+    }
+    let logical_width = max_x - min_x;
+    let logical_height = max_y - min_y;
+    if logical_width <= 0 || logical_height <= 0 {
+        return None;
+    }
+    if unknown_multi_monitor_scale
+        && (i64::from(capture_width) != logical_width
+            || i64::from(capture_height) != logical_height)
+    {
+        return None;
+    }
+    let scale_x = f64::from(capture_width) / logical_width as f64;
+    let scale_y = f64::from(capture_height) / logical_height as f64;
+    if !scale_x.is_finite() || !scale_y.is_finite() || (scale_x - scale_y).abs() > 0.01 {
+        return None;
+    }
+
+    let point = (
+        map_capture_axis(x, capture_width, min_x, max_x - min_x),
+        map_capture_axis(y, capture_height, min_y, max_y - min_y),
+    );
+    streams
+        .iter()
+        .any(|stream| stream.contains_global_point(point.0, point.1))
+        .then_some(point)
+}
+
+fn map_capture_axis(value: i32, capture_size: u32, target_origin: i64, target_size: i64) -> i32 {
+    let scaled = i64::from(value).saturating_mul(target_size) / i64::from(capture_size);
+    target_origin
+        .saturating_add(scaled)
+        .clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
 }
 
 impl PortalStream {
@@ -410,10 +1134,13 @@ async fn create_remote_desktop_session(connection: &Connection) -> Result<OwnedO
     );
     options.insert("session_handle_token", Value::from(session_token.as_str()));
 
-    let handle: OwnedObjectPath = remote_proxy
-        .call("CreateSession", &(options))
-        .await
-        .context("RemoteDesktop CreateSession call failed")?;
+    let handle: OwnedObjectPath = tokio::time::timeout(
+        PORTAL_CALL_TIMEOUT,
+        remote_proxy.call("CreateSession", &(options)),
+    )
+    .await
+    .context("RemoteDesktop CreateSession call timed out")?
+    .context("RemoteDesktop CreateSession call failed")?;
     let (response_code, results) =
         await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
     if response_code != 0 {
@@ -455,10 +1182,13 @@ async fn select_devices(
     );
     options.insert("types", Value::from(device_types));
 
-    let handle: OwnedObjectPath = remote_proxy
-        .call("SelectDevices", &(session, options))
-        .await
-        .context("RemoteDesktop SelectDevices call failed")?;
+    let handle: OwnedObjectPath = tokio::time::timeout(
+        PORTAL_CALL_TIMEOUT,
+        remote_proxy.call("SelectDevices", &(session, options)),
+    )
+    .await
+    .context("RemoteDesktop SelectDevices call timed out")?
+    .context("RemoteDesktop SelectDevices call failed")?;
     let (response_code, _) =
         await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
     if response_code != 0 {
@@ -477,13 +1207,16 @@ async fn select_monitor_sources(connection: &Connection, session: &OwnedObjectPa
         Value::from(last_path_component(&request_path)),
     );
     options.insert("types", Value::from(SOURCE_MONITOR));
-    options.insert("multiple", Value::from(false));
+    options.insert("multiple", Value::from(true));
     options.insert("cursor_mode", Value::from(CURSOR_MODE_HIDDEN));
 
-    let handle: OwnedObjectPath = screencast_proxy
-        .call("SelectSources", &(session, options))
-        .await
-        .context("ScreenCast SelectSources call failed for remote desktop session")?;
+    let handle: OwnedObjectPath = tokio::time::timeout(
+        PORTAL_CALL_TIMEOUT,
+        screencast_proxy.call("SelectSources", &(session, options)),
+    )
+    .await
+    .context("ScreenCast SelectSources call timed out for remote desktop session")?
+    .context("ScreenCast SelectSources call failed for remote desktop session")?;
     let (response_code, _) =
         await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
     if response_code != 0 {
@@ -504,10 +1237,13 @@ async fn start_remote_desktop_session(
         Value::from(last_path_component(&request_path)),
     );
 
-    let handle: OwnedObjectPath = remote_proxy
-        .call("Start", &(session, "", options))
-        .await
-        .context("RemoteDesktop Start call failed")?;
+    let handle: OwnedObjectPath = tokio::time::timeout(
+        PORTAL_CALL_TIMEOUT,
+        remote_proxy.call("Start", &(session, "", options)),
+    )
+    .await
+    .context("RemoteDesktop Start call timed out")?
+    .context("RemoteDesktop Start call failed")?;
     let (response_code, results) =
         await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
     if response_code != 0 {
@@ -534,13 +1270,16 @@ async fn notify_pointer_motion_absolute(
     y: f64,
 ) -> Result<()> {
     let options: HashMap<&str, Value<'_>> = HashMap::new();
-    let _: () = proxy
-        .call(
+    let _: () = tokio::time::timeout(
+        INPUT_TIMEOUT,
+        proxy.call(
             "NotifyPointerMotionAbsolute",
             &(session, options, stream_id, x, y),
-        )
-        .await
-        .context("RemoteDesktop NotifyPointerMotionAbsolute failed")?;
+        ),
+    )
+    .await
+    .context("RemoteDesktop NotifyPointerMotionAbsolute timed out")?
+    .context("RemoteDesktop NotifyPointerMotionAbsolute failed")?;
     Ok(())
 }
 
@@ -551,10 +1290,13 @@ async fn notify_pointer_button(
     state: u32,
 ) -> Result<()> {
     let options: HashMap<&str, Value<'_>> = HashMap::new();
-    let _: () = proxy
-        .call("NotifyPointerButton", &(session, options, button, state))
-        .await
-        .context("RemoteDesktop NotifyPointerButton failed")?;
+    let _: () = tokio::time::timeout(
+        INPUT_TIMEOUT,
+        proxy.call("NotifyPointerButton", &(session, options, button, state)),
+    )
+    .await
+    .context("RemoteDesktop NotifyPointerButton timed out")?
+    .context("RemoteDesktop NotifyPointerButton failed")?;
     Ok(())
 }
 
@@ -565,13 +1307,16 @@ async fn notify_pointer_axis_discrete(
     steps: i32,
 ) -> Result<()> {
     let options: HashMap<&str, Value<'_>> = HashMap::new();
-    let _: () = proxy
-        .call(
+    let _: () = tokio::time::timeout(
+        INPUT_TIMEOUT,
+        proxy.call(
             "NotifyPointerAxisDiscrete",
             &(session, options, axis, steps),
-        )
-        .await
-        .context("RemoteDesktop NotifyPointerAxisDiscrete failed")?;
+        ),
+    )
+    .await
+    .context("RemoteDesktop NotifyPointerAxisDiscrete timed out")?
+    .context("RemoteDesktop NotifyPointerAxisDiscrete failed")?;
     Ok(())
 }
 
@@ -582,10 +1327,13 @@ async fn notify_keyboard_keysym(
     state: u32,
 ) -> Result<()> {
     let options: HashMap<&str, Value<'_>> = HashMap::new();
-    let _: () = proxy
-        .call("NotifyKeyboardKeysym", &(session, options, keysym, state))
-        .await
-        .context("RemoteDesktop NotifyKeyboardKeysym failed")?;
+    let _: () = tokio::time::timeout(
+        INPUT_TIMEOUT,
+        proxy.call("NotifyKeyboardKeysym", &(session, options, keysym, state)),
+    )
+    .await
+    .context("RemoteDesktop NotifyKeyboardKeysym timed out")?
+    .context("RemoteDesktop NotifyKeyboardKeysym failed")?;
     Ok(())
 }
 
@@ -596,11 +1344,42 @@ async fn notify_keyboard_keycode(
     state: u32,
 ) -> Result<()> {
     let options: HashMap<&str, Value<'_>> = HashMap::new();
-    let _: () = proxy
-        .call("NotifyKeyboardKeycode", &(session, options, keycode, state))
-        .await
-        .context("RemoteDesktop NotifyKeyboardKeycode failed")?;
+    let _: () = tokio::time::timeout(
+        INPUT_TIMEOUT,
+        proxy.call("NotifyKeyboardKeycode", &(session, options, keycode, state)),
+    )
+    .await
+    .context("RemoteDesktop NotifyKeyboardKeycode timed out")?
+    .context("RemoteDesktop NotifyKeyboardKeycode failed")?;
     Ok(())
+}
+
+async fn close_portal_session(connection: &Connection, session: &OwnedObjectPath) {
+    if let Ok(proxy) = Proxy::new(
+        connection,
+        PORTAL_DESKTOP_SERVICE,
+        session.as_str(),
+        PORTAL_SESSION_INTERFACE,
+    )
+    .await
+    {
+        let _: Result<(), _> = proxy.call("Close", &()).await;
+    }
+}
+
+fn invalidate_and_close(valid: &AtomicBool, connection: &Connection, session: &OwnedObjectPath) {
+    if !valid.swap(false, Ordering::AcqRel) {
+        return;
+    }
+    let connection = connection.clone();
+    let session = session.clone();
+    if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+        runtime.spawn(async move {
+            let _ =
+                tokio::time::timeout(RELEASE_TIMEOUT, close_portal_session(&connection, &session))
+                    .await;
+        });
+    }
 }
 
 async fn remote_desktop_proxy(connection: &Connection) -> Result<Proxy<'_>> {
@@ -856,6 +1635,364 @@ mod tests {
                 PortalScrollPolarity::InvertVertical
             ),
             (AXIS_VERTICAL, 1)
+        );
+    }
+
+    #[test]
+    fn parses_xrandr_monitor_layout_with_negative_origins() {
+        let layout = parse_xrandr_monitor_layout(
+            "Monitors: 2\n 0: +*eDP-1 1920/344x1080/194+0+0 eDP-1\n 1: +DP-2 2560/600x1440/340-2560+0 DP-2\n",
+        )
+        .expect("XRandR layout should parse");
+
+        assert_eq!(layout.len(), 2);
+        assert_eq!(
+            (layout[0].x, layout[0].y, layout[0].width, layout[0].height),
+            (0, 0, 1920, 1080)
+        );
+        assert_eq!(
+            (layout[1].x, layout[1].y, layout[1].width, layout[1].height),
+            (-2560, 0, 2560, 1440)
+        );
+    }
+
+    #[test]
+    fn parses_hyprland_monitor_layout_in_logical_coordinates() {
+        let layout = parse_hyprland_monitor_layout(
+            br#"[
+                {"x":0,"y":0,"width":3840,"height":2160,"scale":2.0,"transform":0},
+                {"x":1920,"y":0,"width":2560,"height":1440,"scale":1.0,"transform":1}
+            ]"#,
+        )
+        .expect("Hyprland layout should parse");
+
+        assert_eq!(
+            (layout[0].x, layout[0].y, layout[0].width, layout[0].height),
+            (0, 0, 1920, 1080)
+        );
+        assert_eq!(
+            (layout[1].x, layout[1].y, layout[1].width, layout[1].height),
+            (1920, 0, 1440, 2560)
+        );
+    }
+
+    #[test]
+    fn parses_kscreen_physical_sizes_in_logical_coordinates() {
+        let layout = parse_kscreen_monitor_layout(
+            br#"{
+                "outputs":[
+                    {"pos":{"x":0,"y":0},"size":{"width":3840,"height":2160},"scale":2.0,"connected":true,"enabled":true},
+                    {"pos":{"x":1920,"y":0},"size":{"width":1440,"height":2560},"scale":1.0,"connected":true,"enabled":true},
+                    {"pos":{"x":0,"y":0},"size":{"width":0,"height":0},"scale":0.0,"connected":false,"enabled":false}
+                ]
+            }"#,
+        )
+        .expect("KScreen layout should parse");
+
+        assert_eq!(layout.len(), 2);
+        assert_eq!(
+            (layout[0].x, layout[0].y, layout[0].width, layout[0].height),
+            (0, 0, 1920, 1080)
+        );
+        assert_eq!(
+            (layout[1].x, layout[1].y, layout[1].width, layout[1].height),
+            (1920, 0, 1440, 2560)
+        );
+    }
+
+    #[test]
+    fn parses_sway_logical_output_rectangles() {
+        let layout = parse_sway_monitor_layout(
+            br#"[
+                {"active":true,"rect":{"x":-1536,"y":0,"width":1536,"height":864},"scale":1.25},
+                {"active":true,"rect":{"x":0,"y":0,"width":1920,"height":1080},"scale":1.0},
+                {"active":false,"rect":{"x":0,"y":0,"width":0,"height":0},"scale":0.0}
+            ]"#,
+        )
+        .expect("Sway layout should parse");
+
+        assert_eq!(layout.len(), 2);
+        assert_eq!(
+            (
+                layout[0].x,
+                layout[0].y,
+                layout[0].width,
+                layout[0].height,
+                layout[0].scale,
+            ),
+            (-1536, 0, 1536, 864, 1.25)
+        );
+    }
+
+    #[test]
+    fn monitor_parsers_reject_partial_active_layouts() {
+        assert!(parse_hyprland_monitor_layout(
+            br#"[
+                {"x":0,"y":0,"width":1920,"height":1080,"scale":1.0},
+                {"x":1920,"y":0,"width":1920,"height":1080,"scale":0.0}
+            ]"#,
+        )
+        .is_none());
+        assert!(parse_kscreen_monitor_layout(
+            br#"{"outputs":[
+                {"pos":{"x":0,"y":0},"size":{"width":1920,"height":1080},"scale":1.0,"connected":true,"enabled":true},
+                {"pos":{"x":1920,"y":0},"size":{"width":0,"height":1080},"scale":1.0,"connected":true,"enabled":true}
+            ]}"#,
+        )
+        .is_none());
+        assert!(parse_sway_monitor_layout(
+            br#"[
+                {"active":true,"rect":{"x":0,"y":0,"width":1920,"height":1080},"scale":1.0},
+                {"active":true,"rect":{"x":1920,"y":0,"width":1920,"height":1080},"scale":0.0}
+            ]"#,
+        )
+        .is_none());
+        assert!(parse_sway_monitor_layout(
+            br#"[{"rect":{"x":0,"y":0,"width":1920,"height":1080},"scale":1.0}]"#,
+        )
+        .is_none());
+        assert!(parse_xrandr_monitor_layout(
+            "Monitors: 2\n 0: +*eDP-1 1920/344x1080/194+0+0 eDP-1\n"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn monitor_layout_comparison_detects_reconfiguration() {
+        let original = [LogicalMonitor {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            scale: 1.0,
+        }];
+        let mut changed = original.clone();
+        changed[0].scale = 1.25;
+        assert!(!same_monitor_layout(&original, &changed));
+        changed[0].scale = 1.0;
+        changed[0].width = 1600;
+        assert!(!same_monitor_layout(&original, &changed));
+        assert!(same_monitor_layout(&original, &original));
+    }
+
+    #[test]
+    fn capture_points_scale_to_portal_logical_stream_space() {
+        let streams = [PortalStream {
+            node_id: 1,
+            position: Some((0, 0)),
+            size: Some((1920, 1200)),
+        }];
+        let layout = [LogicalMonitor {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1200,
+            scale: 4.0 / 3.0,
+        }];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 1280, 800, 2560, 1600),
+            Some((960, 600))
+        );
+    }
+
+    #[test]
+    fn capture_points_preserve_negative_stream_layout_origins() {
+        let streams = [
+            PortalStream {
+                node_id: 1,
+                position: Some((-1920, 0)),
+                size: Some((1920, 1080)),
+            },
+            PortalStream {
+                node_id: 2,
+                position: Some((0, 0)),
+                size: Some((1920, 1080)),
+            },
+        ];
+        let layout = [
+            LogicalMonitor {
+                x: -1920,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 2.0,
+            },
+            LogicalMonitor {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 2.0,
+            },
+        ];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 0, 0, 7680, 2160),
+            Some((-1920, 0))
+        );
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 3840, 1080, 7680, 2160),
+            Some((0, 540))
+        );
+    }
+
+    #[test]
+    fn capture_point_mapping_requires_usable_stream_metadata() {
+        let streams = [PortalStream {
+            node_id: 1,
+            position: None,
+            size: None,
+        }];
+        let layout = [LogicalMonitor {
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1200,
+            scale: 1.0,
+        }];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 100, 200, 2560, 1600),
+            None
+        );
+    }
+
+    #[test]
+    fn capture_point_mapping_rejects_invalid_desktop_monitors() {
+        let streams = [PortalStream {
+            node_id: 1,
+            position: Some((0, 0)),
+            size: Some((1920, 1080)),
+        }];
+        let layout = [
+            LogicalMonitor {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 1.0,
+            },
+            LogicalMonitor {
+                x: 1920,
+                y: 0,
+                width: 0,
+                height: 1080,
+                scale: 1.0,
+            },
+        ];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 100, 200, 1920, 1080),
+            None
+        );
+    }
+
+    #[test]
+    fn capture_point_mapping_rejects_partially_shared_desktops() {
+        let streams = [PortalStream {
+            node_id: 1,
+            position: Some((0, 0)),
+            size: Some((1920, 1080)),
+        }];
+        let layout = [
+            LogicalMonitor {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 1.0,
+            },
+            LogicalMonitor {
+                x: 1920,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 1.0,
+            },
+        ];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 3000, 500, 3840, 1080),
+            None
+        );
+    }
+
+    #[test]
+    fn capture_point_mapping_rejects_mixed_scale_desktops() {
+        let streams = [
+            PortalStream {
+                node_id: 1,
+                position: Some((0, 0)),
+                size: Some((1920, 1080)),
+            },
+            PortalStream {
+                node_id: 2,
+                position: Some((1920, 0)),
+                size: Some((1920, 1080)),
+            },
+        ];
+        let layout = [
+            LogicalMonitor {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 1.0,
+            },
+            LogicalMonitor {
+                x: 1920,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 2.0,
+            },
+        ];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 2000, 500, 3840, 1080),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_multi_monitor_scale_only_allows_identity_mapping() {
+        let streams = [
+            PortalStream {
+                node_id: 1,
+                position: Some((0, 0)),
+                size: Some((1920, 1080)),
+            },
+            PortalStream {
+                node_id: 2,
+                position: Some((1920, 0)),
+                size: Some((1920, 1080)),
+            },
+        ];
+        let layout = [
+            LogicalMonitor {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 0.0,
+            },
+            LogicalMonitor {
+                x: 1920,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale: 0.0,
+            },
+        ];
+
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 2500, 500, 3840, 1080),
+            Some((2500, 500))
+        );
+        assert_eq!(
+            map_capture_point_to_stream_layout(&streams, &layout, 5000, 1000, 7680, 2160),
+            None
         );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,8 +19,9 @@ use crate::windowing::registry;
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
     window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
-    GNOME_SHELL_INTROSPECT_BACKEND,
+    GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
 };
+use crate::ydotool;
 use anyhow::Result;
 use rmcp::{
     handler::server::wrapper::{Json, Parameters},
@@ -32,20 +33,19 @@ use serde::{Deserialize, Serialize};
 use std::{
     env,
     future::Future,
-    os::unix::net::{UnixDatagram, UnixStream},
-    path::PathBuf,
+    os::unix::net::UnixDatagram,
+    path::{Path, PathBuf},
     process::{Command, Output, Stdio},
     sync::{Arc, Mutex},
     time::Duration,
 };
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
-    process::{Child as TokioChild, Command as TokioCommand},
+    process::Command as TokioCommand,
     time::{sleep, timeout},
 };
 use zbus::{Connection as ZbusConnection, Proxy as ZbusProxy};
 
-const YDOTOOL_TIMEOUT: Duration = Duration::from_secs(10);
+const INPUT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const YDOTOOL_TYPE_CHARS_PER_SECOND: u64 = 20;
 const KDE_CLIPBOARD_DBUS_TIMEOUT: Duration = Duration::from_secs(3);
 const KDE_KLIPPER_SERVICE: &str = "org.kde.klipper";
@@ -59,10 +59,11 @@ pub struct ComputerUseLinux {
     portal_keyboard_session: Arc<Mutex<Option<PortalKeyboardSession>>>,
     /// Lazily-created uinput absolute pointer (preferred coordinate backend).
     abs_pointer: Arc<Mutex<Option<crate::abs_pointer::AbsPointer>>>,
-    portal_keyboard_init_lock: Arc<tokio::sync::Mutex<()>>,
+    portal_session_init_lock: Arc<tokio::sync::Mutex<()>>,
+    input_operation_lock: Arc<tokio::sync::Mutex<()>>,
     kde_clipboard_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Cached logical desktop size (union of monitors) from the most recent
-    /// full-frame capture; used for off-screen window/coordinate warnings.
+    /// Cached physical desktop size from the most recent full-frame capture;
+    /// used for off-screen warnings and portal logical-coordinate mapping.
     desktop_size: Arc<Mutex<Option<(u32, u32)>>>,
 }
 
@@ -122,8 +123,12 @@ impl ComputerUseLinux {
             open_world_hint = false
         )
     )]
-    fn doctor(&self) -> Json<DoctorReport> {
-        Json(doctor_report())
+    async fn doctor(&self) -> Json<DoctorReport> {
+        Json(
+            tokio::task::spawn_blocking(doctor_report)
+                .await
+                .expect("diagnostics task panicked"),
+        )
     }
 
     #[tool(
@@ -136,8 +141,12 @@ impl ComputerUseLinux {
             open_world_hint = false
         )
     )]
-    fn setup_accessibility(&self) -> Json<SetupReport> {
-        Json(setup_accessibility_report())
+    async fn setup_accessibility(&self) -> Json<SetupReport> {
+        Json(
+            tokio::task::spawn_blocking(setup_accessibility_report)
+                .await
+                .expect("accessibility setup task panicked"),
+        )
     }
 
     #[tool(
@@ -288,7 +297,9 @@ impl ComputerUseLinux {
         Parameters(params): Parameters<GetAppStateParams>,
     ) -> Json<GetAppStateOutput> {
         let verbose = params.verbose.unwrap_or(false);
-        let diagnostics = doctor_report();
+        let diagnostics = tokio::task::spawn_blocking(doctor_report)
+            .await
+            .expect("diagnostics task panicked");
         let (window_context, window_error, window_permissions_hint) =
             self.resolve_window_context(&params).await;
         let max_nodes = params.max_nodes.unwrap_or(120).clamp(1, 500);
@@ -300,16 +311,15 @@ impl ComputerUseLinux {
             .resolve_accessibility_app_filter(&params, window_context.as_ref())
             .await;
         let (screenshot, screenshot_error) = if include_screenshot {
-            let result = capture_screenshot_raw().await.and_then(|raw| {
+            let result: Result<ScreenshotCapture> = async {
+                let raw = capture_screenshot_raw().await?;
+                self.cache_desktop_size(raw.width, raw.height);
                 if let Some(window) = window_context.as_ref() {
-                    let bounds = window.bounds.as_ref().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "targeted screenshot requires window bounds; refusing to return the full desktop"
-                        )
-                    })?;
+                    ensure_readonly_screenshot_target_is_visible(window)?;
+                    let crop = self.window_crop_rect_for_capture(window, &raw).await?;
                     prepare_app_state_screenshot(
                         raw,
-                        Some(bounds),
+                        Some(crop),
                         screenshot_target_requested,
                         screenshot_options,
                     )
@@ -321,7 +331,8 @@ impl ComputerUseLinux {
                         screenshot_options,
                     )
                 }
-            });
+            }
+            .await;
             match result {
                 Ok(capture) => (Some(capture), None),
                 Err(error) => (None, Some(format!("{error:#}"))),
@@ -429,25 +440,25 @@ impl ComputerUseLinux {
         Parameters(params): Parameters<ScreenshotParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let target = params.window_target();
-
-        // When targeting a window, raise it first (so it isn't occluded) and
-        // resolve its bounds so we can crop to just that window.
-        let mut crop: Option<crate::windowing::WindowBounds> = None;
-        let mut window_label: Option<String> = None;
-        if let Some(target) = &target {
-            if params.raise_window.unwrap_or(true) {
-                let _ = focus_window_target(target).await;
-                tokio::time::sleep(Duration::from_millis(250)).await;
-            }
-            if !params.full_screen.unwrap_or(false) {
-                if let Ok(windows) = list_windows().await {
-                    if let Ok(window) = resolve_window_target(&windows, target) {
-                        crop = window.bounds.clone();
-                        window_label = window.title.clone();
-                    }
-                }
-            }
-        }
+        let target_window = match target.as_ref() {
+            Some(target) => Some(
+                self.resolve_screenshot_window(target, params.raise_window.unwrap_or(true))
+                    .await
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("targeted screenshot failed: {error:#}"),
+                            None,
+                        )
+                    })?,
+            ),
+            None => None,
+        };
+        let crop_window = (!params.full_screen.unwrap_or(false))
+            .then_some(target_window.as_ref())
+            .flatten();
+        let window_label = target_window
+            .as_ref()
+            .and_then(|window| window.title.clone());
 
         let raw_capture = capture_screenshot_raw()
             .await
@@ -457,26 +468,40 @@ impl ComputerUseLinux {
         // Warn when the target window extends past the visible desktop: the
         // portal only captures on-screen pixels, so the crop silently loses the
         // off-screen region while coordinate metadata still claims full size.
-        let off_screen_note = match crop.as_ref() {
+        let off_screen_note = match crop_window.and_then(|window| window.bounds.as_ref()) {
             Some(bounds) => self.off_screen_note_for_bounds(bounds).await,
             None => None,
         };
 
-        let (capture, cropped) = match crop.as_ref().and_then(window_crop_rect) {
-            Some((x, y, w, h)) => match crop_png(&raw_capture.bytes, x, y, w, h) {
-                Ok((bytes, cw, ch)) => (
+        let (capture, cropped) = match crop_window {
+            Some(window) => {
+                let (x, y, width, height) = self
+                    .window_crop_rect_for_capture(window, &raw_capture)
+                    .await
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("targeted screenshot crop failed: {error:#}"),
+                            None,
+                        )
+                    })?;
+                let (bytes, width, height) = crop_png(&raw_capture.bytes, x, y, width, height)
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("targeted screenshot crop failed: {error}"),
+                            None,
+                        )
+                    })?;
+                (
                     RawScreenshotCapture {
-                        mime_type: raw_capture.mime_type.clone(),
+                        mime_type: raw_capture.mime_type,
                         bytes,
-                        source: raw_capture.source.clone(),
-                        width: cw,
-                        height: ch,
+                        source: raw_capture.source,
+                        width,
+                        height,
                     },
                     true,
-                ),
-                // If cropping fails, fall back to the full frame rather than erroring.
-                Err(_) => (raw_capture, false),
-            },
+                )
+            }
             None => (raw_capture, false),
         };
         let capture =
@@ -581,6 +606,8 @@ impl ComputerUseLinux {
     )]
     async fn click(&self, Parameters(mut params): Parameters<ClickParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
+        let _input_guard = self.input_operation_lock.lock().await;
+        let mut portal_target_point = None;
         // Raise the target window first (if specified) so the click lands on the
         // intended app rather than whatever is stacked on top at that pixel.
         let window_target = params.window_target();
@@ -620,7 +647,22 @@ impl ComputerUseLinux {
                         received,
                     });
                 };
-                if let Err(message) = apply_window_relative_click_coordinates(&mut params, focus) {
+                let coordinate_map = match self.focused_window_coordinate_map(focus).await {
+                    Ok(mapping) => mapping,
+                    Err(message) => {
+                        return Json(ActionOutput {
+                            ok: false,
+                            implemented: true,
+                            action: "click".to_string(),
+                            message,
+                            received,
+                        });
+                    }
+                };
+                if let Err(message) = apply_window_relative_click_coordinates(
+                    &mut params,
+                    coordinate_map.capture_rect,
+                ) {
                     return Json(ActionOutput {
                         ok: false,
                         implemented: true,
@@ -629,6 +671,10 @@ impl ComputerUseLinux {
                         received,
                     });
                 }
+                portal_target_point = params
+                    .x
+                    .zip(params.y)
+                    .and_then(|(x, y)| coordinate_map.portal_point(x, y));
             }
         }
         let target = match self.resolve_click_target(&params) {
@@ -720,10 +766,19 @@ impl ComputerUseLinux {
             ));
         }
         if let Some(session) = self.cached_portal_pointer_session() {
+            let Some((portal_x, portal_y)) =
+                portal_target_point.or_else(|| self.logical_portal_point(&session, x, y))
+            else {
+                self.clear_portal_pointer_session(&session);
+                return Json(with_notes(
+                    portal_coordinate_error("click", received),
+                    off_screen_note.clone(),
+                ));
+            };
             match portal_click(
                 &session,
-                x,
-                y,
+                portal_x,
+                portal_y,
                 PointerButton::from_name(params.button.as_deref()),
                 params.click_count.unwrap_or(1).clamp(1, 10),
             )
@@ -741,34 +796,57 @@ impl ComputerUseLinux {
                         off_screen_note.clone(),
                     ));
                 }
-                Err(_) => self.clear_portal_pointer_session(),
+                Err(error) => {
+                    self.clear_portal_pointer_session(&session);
+                    return Json(with_notes(
+                        portal_action_error("click", error, received),
+                        off_screen_note.clone(),
+                    ));
+                }
             }
-        } else if self.should_prefer_portal_pointer_backend() {
+        } else if self.should_prefer_portal_pointer_backend().await {
             match self.ensure_portal_pointer_session().await {
-                Ok(Some(session)) => match portal_click(
-                    &session,
-                    x,
-                    y,
-                    PointerButton::from_name(params.button.as_deref()),
-                    params.click_count.unwrap_or(1).clamp(1, 10),
-                )
-                .await
-                {
-                    Ok(()) => {
+                Ok(Some(session)) => {
+                    let Some((portal_x, portal_y)) =
+                        portal_target_point.or_else(|| self.logical_portal_point(&session, x, y))
+                    else {
+                        self.clear_portal_pointer_session(&session);
                         return Json(with_notes(
-                            ActionOutput {
-                                ok: true,
-                                implemented: true,
-                                action: "click".to_string(),
-                                message: "Action sent through the remote desktop portal."
-                                    .to_string(),
-                                received,
-                            },
+                            portal_coordinate_error("click", received),
                             off_screen_note.clone(),
                         ));
+                    };
+                    match portal_click(
+                        &session,
+                        portal_x,
+                        portal_y,
+                        PointerButton::from_name(params.button.as_deref()),
+                        params.click_count.unwrap_or(1).clamp(1, 10),
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            return Json(with_notes(
+                                ActionOutput {
+                                    ok: true,
+                                    implemented: true,
+                                    action: "click".to_string(),
+                                    message: "Action sent through the remote desktop portal."
+                                        .to_string(),
+                                    received,
+                                },
+                                off_screen_note.clone(),
+                            ));
+                        }
+                        Err(error) => {
+                            self.clear_portal_pointer_session(&session);
+                            return Json(with_notes(
+                                portal_action_error("click", error, received),
+                                off_screen_note.clone(),
+                            ));
+                        }
                     }
-                    Err(_) => self.clear_portal_pointer_session(),
-                },
+                }
                 Ok(None) => {}
                 Err(_) => {}
             }
@@ -878,6 +956,8 @@ impl ComputerUseLinux {
     )]
     async fn scroll(&self, Parameters(mut params): Parameters<ScrollParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
+        let _input_guard = self.input_operation_lock.lock().await;
+        let mut portal_target_point = None;
         let units = ((params.pages.unwrap_or(1.0).abs().max(0.1) * 5.0).round() as i32).max(1);
         // Raise/focus the target window first (parity with click) so wheel
         // events land on the intended app.
@@ -917,7 +997,22 @@ impl ComputerUseLinux {
                         received,
                     });
                 };
-                if let Err(message) = apply_window_relative_scroll_coordinates(&mut params, focus) {
+                let coordinate_map = match self.focused_window_coordinate_map(focus).await {
+                    Ok(mapping) => mapping,
+                    Err(message) => {
+                        return Json(ActionOutput {
+                            ok: false,
+                            implemented: true,
+                            action: "scroll".to_string(),
+                            message,
+                            received,
+                        });
+                    }
+                };
+                if let Err(message) = apply_window_relative_scroll_coordinates(
+                    &mut params,
+                    coordinate_map.capture_rect,
+                ) {
                     return Json(ActionOutput {
                         ok: false,
                         implemented: true,
@@ -926,6 +1021,10 @@ impl ComputerUseLinux {
                         received,
                     });
                 }
+                portal_target_point = params
+                    .x
+                    .zip(params.y)
+                    .and_then(|(x, y)| coordinate_map.portal_point(x, y));
             } else if params.x.is_none() && params.y.is_none() && params.element_index.is_none() {
                 // A window target without a point would otherwise scroll
                 // whatever happens to sit under the pointer: focusing does not
@@ -941,7 +1040,21 @@ impl ComputerUseLinux {
                         received,
                     });
                 };
-                if let Err(message) = apply_window_center_scroll_point(&mut params, focus) {
+                let coordinate_map = match self.focused_window_coordinate_map(focus).await {
+                    Ok(mapping) => mapping,
+                    Err(message) => {
+                        return Json(ActionOutput {
+                            ok: false,
+                            implemented: true,
+                            action: "scroll".to_string(),
+                            message,
+                            received,
+                        });
+                    }
+                };
+                if let Err(message) =
+                    apply_window_center_scroll_point(&mut params, coordinate_map.capture_rect)
+                {
                     return Json(ActionOutput {
                         ok: false,
                         implemented: true,
@@ -950,6 +1063,10 @@ impl ComputerUseLinux {
                         received,
                     });
                 }
+                portal_target_point = params
+                    .x
+                    .zip(params.y)
+                    .and_then(|(x, y)| coordinate_map.portal_point(x, y));
             }
         }
         let target_point =
@@ -985,9 +1102,20 @@ impl ComputerUseLinux {
             Some((x, y)) => self.off_screen_note_for_point(x, y).await,
             None => None,
         };
-
         if let Some(session) = self.cached_portal_pointer_session() {
-            match portal_scroll(&session, target_point, direction, units).await {
+            let mapped_target = match (portal_target_point, target_point) {
+                (Some(point), _) => Some(Some(point)),
+                (None, Some((x, y))) => self.logical_portal_point(&session, x, y).map(Some),
+                (None, None) => Some(None),
+            };
+            let Some(portal_target_point) = mapped_target else {
+                self.clear_portal_pointer_session(&session);
+                return Json(with_notes(
+                    portal_coordinate_error("scroll", received),
+                    off_screen_note.clone(),
+                ));
+            };
+            match portal_scroll(&session, portal_target_point, direction, units).await {
                 Ok(()) => {
                     return Json(with_notes(
                         ActionOutput {
@@ -1000,12 +1128,30 @@ impl ComputerUseLinux {
                         off_screen_note.clone(),
                     ));
                 }
-                Err(_) => self.clear_portal_pointer_session(),
+                Err(error) => {
+                    self.clear_portal_pointer_session(&session);
+                    return Json(with_notes(
+                        portal_action_error("scroll", error, received),
+                        off_screen_note.clone(),
+                    ));
+                }
             }
-        } else if self.should_prefer_portal_pointer_backend() {
+        } else if self.should_prefer_portal_pointer_backend().await {
             match self.ensure_portal_pointer_session().await {
                 Ok(Some(session)) => {
-                    match portal_scroll(&session, target_point, direction, units).await {
+                    let mapped_target = match (portal_target_point, target_point) {
+                        (Some(point), _) => Some(Some(point)),
+                        (None, Some((x, y))) => self.logical_portal_point(&session, x, y).map(Some),
+                        (None, None) => Some(None),
+                    };
+                    let Some(portal_target_point) = mapped_target else {
+                        self.clear_portal_pointer_session(&session);
+                        return Json(with_notes(
+                            portal_coordinate_error("scroll", received),
+                            off_screen_note.clone(),
+                        ));
+                    };
+                    match portal_scroll(&session, portal_target_point, direction, units).await {
                         Ok(()) => {
                             return Json(with_notes(
                                 ActionOutput {
@@ -1019,7 +1165,13 @@ impl ComputerUseLinux {
                                 off_screen_note.clone(),
                             ));
                         }
-                        Err(_) => self.clear_portal_pointer_session(),
+                        Err(error) => {
+                            self.clear_portal_pointer_session(&session);
+                            return Json(with_notes(
+                                portal_action_error("scroll", error, received),
+                                off_screen_note.clone(),
+                            ));
+                        }
                     }
                 }
                 Ok(None) => {}
@@ -1066,6 +1218,7 @@ impl ComputerUseLinux {
     )]
     async fn drag(&self, Parameters(params): Parameters<DragParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
+        let _input_guard = self.input_operation_lock.lock().await;
         // Preferred backend: the uinput absolute pointer (accurate landing).
         if self.ensure_abs_pointer().await {
             let abs_pointer = Arc::clone(&self.abs_pointer);
@@ -1097,15 +1250,20 @@ impl ComputerUseLinux {
             }
         }
         if let Some(session) = self.cached_portal_pointer_session() {
-            match portal_drag(
-                &session,
-                params.start_x,
-                params.start_y,
-                params.end_x,
-                params.end_y,
-            )
-            .await
-            {
+            let _ = self.capture_space_rect().await;
+            let Some((start_x, start_y)) =
+                self.logical_portal_point(&session, params.start_x, params.start_y)
+            else {
+                self.clear_portal_pointer_session(&session);
+                return Json(portal_coordinate_error("drag", received));
+            };
+            let Some((end_x, end_y)) =
+                self.logical_portal_point(&session, params.end_x, params.end_y)
+            else {
+                self.clear_portal_pointer_session(&session);
+                return Json(portal_coordinate_error("drag", received));
+            };
+            match portal_drag(&session, start_x, start_y, end_x, end_y).await {
                 Ok(()) => {
                     return Json(ActionOutput {
                         ok: true,
@@ -1115,30 +1273,44 @@ impl ComputerUseLinux {
                         received,
                     });
                 }
-                Err(_) => self.clear_portal_pointer_session(),
+                Err(error) => {
+                    self.clear_portal_pointer_session(&session);
+                    return Json(portal_action_error("drag", error, received));
+                }
             }
-        } else if self.should_prefer_portal_pointer_backend() {
+        } else if self.should_prefer_portal_pointer_backend().await {
+            let _ = self.capture_space_rect().await;
             match self.ensure_portal_pointer_session().await {
-                Ok(Some(session)) => match portal_drag(
-                    &session,
-                    params.start_x,
-                    params.start_y,
-                    params.end_x,
-                    params.end_y,
-                )
-                .await
-                {
-                    Ok(()) => {
-                        return Json(ActionOutput {
-                            ok: true,
-                            implemented: true,
-                            action: "drag".to_string(),
-                            message: "Action sent through the remote desktop portal.".to_string(),
-                            received,
-                        });
+                Ok(Some(session)) => {
+                    let Some((start_x, start_y)) =
+                        self.logical_portal_point(&session, params.start_x, params.start_y)
+                    else {
+                        self.clear_portal_pointer_session(&session);
+                        return Json(portal_coordinate_error("drag", received));
+                    };
+                    let Some((end_x, end_y)) =
+                        self.logical_portal_point(&session, params.end_x, params.end_y)
+                    else {
+                        self.clear_portal_pointer_session(&session);
+                        return Json(portal_coordinate_error("drag", received));
+                    };
+                    match portal_drag(&session, start_x, start_y, end_x, end_y).await {
+                        Ok(()) => {
+                            return Json(ActionOutput {
+                                ok: true,
+                                implemented: true,
+                                action: "drag".to_string(),
+                                message: "Action sent through the remote desktop portal."
+                                    .to_string(),
+                                received,
+                            });
+                        }
+                        Err(error) => {
+                            self.clear_portal_pointer_session(&session);
+                            return Json(portal_action_error("drag", error, received));
+                        }
                     }
-                    Err(_) => self.clear_portal_pointer_session(),
-                },
+                }
                 Ok(None) => {}
                 Err(_) => {}
             }
@@ -1168,6 +1340,7 @@ impl ComputerUseLinux {
         Parameters(params): Parameters<PressKeyParams>,
     ) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
+        let _input_guard = self.input_operation_lock.lock().await;
         let focus = match self.focus_target_for_input(&params.window_target()).await {
             Ok(focus) => focus,
             Err(message) => {
@@ -1189,7 +1362,7 @@ impl ComputerUseLinux {
                 received,
             });
         };
-        if self.should_prefer_portal_keyboard_for_chords() {
+        if self.should_prefer_portal_keyboard_for_chords().await {
             match self.ensure_portal_keyboard_session().await {
                 Ok(Some(session)) => {
                     let modifiers: Vec<i32> =
@@ -1208,7 +1381,7 @@ impl ComputerUseLinux {
                             ));
                         }
                         Err(error) => {
-                            self.clear_portal_keyboard_session();
+                            self.clear_portal_keyboard_session(&session);
                             return Json(action_result_with_focus(
                                 "press_key",
                                 Err(format!("{error:#}")),
@@ -1236,22 +1409,30 @@ impl ComputerUseLinux {
         // arrive as stray glyphs instead of real key events (issue #58).
         if self.should_prefer_xdotool_keyboard() {
             if let Some(spec) = xdotool_key_spec(&params.key) {
-                let args = vec!["key".to_string(), "--clearmodifiers".to_string(), spec];
-                // On error, fall through to ydotool rather than failing outright.
-                if let Ok(output) = run_xdotool(&args).await {
-                    let mut result = action_result_with_focus(
-                        "press_key",
-                        Ok(vec![output]),
-                        received,
-                        focus.clone(),
-                    );
-                    result.message = "Action sent through xdotool (X11 XTEST).".to_string();
-                    if result.ok && focus.is_some() {
-                        let notes = self.input_landing_notes(focus.as_ref(), false).await;
-                        result = with_notes(result, notes);
-                    }
-                    return Json(result);
+                let xdotool_args = vec!["key".to_string(), "--clearmodifiers".to_string(), spec];
+                let ydotool_args =
+                    ydotool_key_args(key_events.clone(), !chord_modifiers.is_empty());
+                let result = run_xdotool_or_fallback(Path::new("xdotool"), &xdotool_args, || {
+                    run_ydotool(&ydotool_args)
+                })
+                .await;
+                let used_xdotool = result
+                    .as_ref()
+                    .is_ok_and(|result| result.backend == KeyboardCommandBackend::Xdotool);
+                let mut output = action_result_with_focus(
+                    "press_key",
+                    result.map(|result| vec![result.output]),
+                    received,
+                    focus.clone(),
+                );
+                if used_xdotool {
+                    output.message = "Action sent through xdotool (X11 XTEST).".to_string();
                 }
+                if output.ok && focus.is_some() {
+                    let notes = self.input_landing_notes(focus.as_ref(), false).await;
+                    output = with_notes(output, notes);
+                }
+                return Json(output);
             }
         }
         let args = ydotool_key_args(key_events, !chord_modifiers.is_empty());
@@ -1279,6 +1460,7 @@ impl ComputerUseLinux {
         Parameters(params): Parameters<TypeTextParams>,
     ) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
+        let _input_guard = self.input_operation_lock.lock().await;
         let focus = match self.focus_target_for_input(&params.window_target()).await {
             Ok(focus) => focus,
             Err(message) => {
@@ -1310,7 +1492,7 @@ impl ComputerUseLinux {
                         }
                         Err(error) => {
                             if error.clear_portal_keyboard_session {
-                                self.clear_portal_keyboard_session();
+                                self.clear_portal_keyboard_session(&session);
                             }
                             if !error.can_fallback_to_ydotool {
                                 return Json(action_result_with_focus(
@@ -1327,7 +1509,7 @@ impl ComputerUseLinux {
                 Err(_) => {}
             }
         }
-        if self.should_prefer_portal_keyboard_backend() {
+        if self.should_prefer_portal_keyboard_backend().await {
             if let Ok(keysyms) = keysyms_for_text(&params.text) {
                 match self.ensure_portal_keyboard_session().await {
                     Ok(Some(session)) => match type_text_with_keysyms(&session, &keysyms).await {
@@ -1344,7 +1526,7 @@ impl ComputerUseLinux {
                             ));
                         }
                         Err(error) => {
-                            self.clear_portal_keyboard_session();
+                            self.clear_portal_keyboard_session(&session);
                             return Json(action_result_with_focus(
                                 "type_text",
                                 Err(format!("{error:#}")),
@@ -1362,27 +1544,28 @@ impl ComputerUseLinux {
         // ydotool's raw scancodes get re-mapped by X11 and mangle symbols and
         // digits (`_` → `%`, `1` → `+`) even on a plain US layout (issue #58).
         if self.should_prefer_xdotool_keyboard() {
-            let args = vec![
-                "type".to_string(),
-                "--clearmodifiers".to_string(),
-                "--".to_string(),
-                params.text.clone(),
-            ];
-            // On error, fall through to ydotool rather than failing outright.
-            if let Ok(output) = run_xdotool(&args).await {
-                let mut result = action_result_with_focus(
-                    "type_text",
-                    Ok(vec![output]),
-                    received,
-                    focus.clone(),
-                );
-                result.message = "Action sent through xdotool (X11 XTEST).".to_string();
-                if result.ok && focus.is_some() {
-                    let notes = self.input_landing_notes(focus.as_ref(), true).await;
-                    result = with_notes(result, notes);
-                }
-                return Json(result);
+            let args = xdotool_type_args(&params.text);
+            let result = run_xdotool_or_fallback(Path::new("xdotool"), &args, || {
+                run_ydotool_type_text(&params.text)
+            })
+            .await;
+            let used_xdotool = result
+                .as_ref()
+                .is_ok_and(|result| result.backend == KeyboardCommandBackend::Xdotool);
+            let mut output = action_result_with_focus(
+                "type_text",
+                result.map(|result| vec![result.output]),
+                received,
+                focus.clone(),
+            );
+            if used_xdotool {
+                output.message = "Action sent through xdotool (X11 XTEST).".to_string();
             }
+            if output.ok && focus.is_some() {
+                let notes = self.input_landing_notes(focus.as_ref(), true).await;
+                output = with_notes(output, notes);
+            }
+            return Json(output);
         }
         let result = run_ydotool_type_text(&params.text)
             .await
@@ -2050,30 +2233,41 @@ impl ComputerUseLinux {
     }
 
     // The Wayland remote-desktop portal is now a *fallback* for input: when a
-    // working `ydotoold` socket is present we prefer ydotool, because it injects
-    // input without a permission prompt. GNOME refuses to persist remote-desktop
+    // compatible ydotool CLI and working `ydotoold` socket are present we prefer
+    // ydotool, because it injects input without a permission prompt. GNOME
+    // refuses to persist remote-desktop
     // grants (`org.freedesktop.portal.Error: Remote desktop sessions cannot
     // persist`), so the portal would otherwise re-prompt on every new session.
     // `COMPUTER_USE_LINUX_FORCE_YDOTOOL_*=1` always uses ydotool;
     // `COMPUTER_USE_LINUX_FORCE_PORTAL_*=1` always uses the portal.
-    fn should_prefer_portal_pointer_backend(&self) -> bool {
+    async fn should_prefer_portal_pointer_backend(&self) -> bool {
         if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_YDOTOOL_POINTER") {
             return false;
         }
         if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_PORTAL_POINTER") {
             return self.is_wayland_session();
         }
-        self.is_wayland_session() && ydotool_socket().is_none()
+        should_prefer_portal_backend_by_default(
+            self.is_wayland_session(),
+            ydotool_backend_available().await,
+        )
     }
 
-    fn should_prefer_portal_keyboard_backend(&self) -> bool {
+    async fn should_prefer_portal_keyboard_backend(&self) -> bool {
         if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD") {
+            return false;
+        }
+        if self.should_prefer_xdotool_keyboard() {
             return false;
         }
         if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_PORTAL_KEYBOARD") {
             return self.is_wayland_session() && !self.is_kde_wayland_session();
         }
-        self.is_wayland_session() && !self.is_kde_wayland_session() && ydotool_socket().is_none()
+        !self.is_kde_wayland_session()
+            && should_prefer_portal_backend_by_default(
+                self.is_wayland_session(),
+                ydotool_backend_available().await,
+            )
     }
 
     /// Portal keyboard policy for `press_key` chords. Unlike literal text
@@ -2084,8 +2278,11 @@ impl ComputerUseLinux {
     /// when ydotool is available, so the consent the user already granted
     /// keeps covering key chords; otherwise the portal is preferred only
     /// when ydotool is absent or the portal is forced.
-    fn should_prefer_portal_keyboard_for_chords(&self) -> bool {
+    async fn should_prefer_portal_keyboard_for_chords(&self) -> bool {
         if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD") {
+            return false;
+        }
+        if self.should_prefer_xdotool_keyboard() {
             return false;
         }
         if !self.is_wayland_session() {
@@ -2096,11 +2293,12 @@ impl ComputerUseLinux {
         {
             return true;
         }
-        ydotool_socket().is_none()
+        !ydotool_backend_available().await
     }
 
     fn should_prefer_kde_clipboard_text_backend(&self) -> bool {
         !env_flag_enabled("COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD")
+            && !self.should_prefer_xdotool_keyboard()
             && self.is_kde_wayland_session()
     }
 
@@ -2115,13 +2313,13 @@ impl ComputerUseLinux {
     /// `COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD=1` opts out;
     /// `COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD=1` forces it on.
     fn should_prefer_xdotool_keyboard(&self) -> bool {
-        if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD") {
-            return false;
-        }
-        if env_flag_enabled("COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD") {
-            return xdotool_available();
-        }
-        !self.is_wayland_session() && env_var_non_empty("DISPLAY") && xdotool_available()
+        prefer_xdotool_keyboard(
+            env_flag_enabled("COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD"),
+            env_flag_enabled("COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD"),
+            self.is_wayland_session(),
+            env_var_non_empty("DISPLAY"),
+            xdotool_available(),
+        )
     }
 
     fn is_kde_wayland_session(&self) -> bool {
@@ -2131,35 +2329,54 @@ impl ComputerUseLinux {
     }
 
     fn cached_portal_pointer_session(&self) -> Option<PortalPointerSession> {
-        self.portal_pointer_session
-            .lock()
-            .ok()
-            .and_then(|cached| cached.clone())
+        let mut cached = self.portal_pointer_session.lock().ok()?;
+        if cached.as_ref().is_some_and(|session| !session.is_valid()) {
+            *cached = None;
+        }
+        cached.clone()
     }
 
-    fn clear_portal_pointer_session(&self) {
+    fn clear_portal_pointer_session(&self, failed: &PortalPointerSession) {
+        failed.invalidate_and_close();
         if let Ok(mut cached) = self.portal_pointer_session.lock() {
-            *cached = None;
+            if cached
+                .as_ref()
+                .is_some_and(|session| session.same_session(failed))
+            {
+                *cached = None;
+            }
         }
     }
 
     fn cached_portal_keyboard_session(&self) -> Option<PortalKeyboardSession> {
-        self.portal_keyboard_session
-            .lock()
-            .ok()
-            .and_then(|cached| cached.clone())
+        let mut cached = self.portal_keyboard_session.lock().ok()?;
+        if cached.as_ref().is_some_and(|session| !session.is_valid()) {
+            *cached = None;
+        }
+        cached.clone()
     }
 
-    fn clear_portal_keyboard_session(&self) {
+    fn clear_portal_keyboard_session(&self, failed: &PortalKeyboardSession) {
+        failed.invalidate_and_close();
         if let Ok(mut cached) = self.portal_keyboard_session.lock() {
-            *cached = None;
+            if cached
+                .as_ref()
+                .is_some_and(|session| session.same_session(failed))
+            {
+                *cached = None;
+            }
         }
     }
 
     async fn ensure_portal_pointer_session(&self) -> Result<Option<PortalPointerSession>> {
-        if !self.should_prefer_portal_pointer_backend() {
+        if !self.should_prefer_portal_pointer_backend().await {
             return Ok(None);
         }
+        if let Some(session) = self.cached_portal_pointer_session() {
+            return Ok(Some(session));
+        }
+
+        let _guard = self.portal_session_init_lock.lock().await;
         if let Some(session) = self.cached_portal_pointer_session() {
             return Ok(Some(session));
         }
@@ -2181,7 +2398,7 @@ impl ComputerUseLinux {
             return Ok(Some(session));
         }
 
-        let _guard = self.portal_keyboard_init_lock.lock().await;
+        let _guard = self.portal_session_init_lock.lock().await;
         if let Some(session) = self.cached_portal_keyboard_session() {
             return Ok(Some(session));
         }
@@ -2213,6 +2430,152 @@ impl ComputerUseLinux {
                 (None, Some(error), hint)
             }
         }
+    }
+
+    async fn resolve_screenshot_window(
+        &self,
+        target: &WindowTarget,
+        raise_window: bool,
+    ) -> Result<WindowInfo> {
+        let window = if raise_window {
+            let focus = focus_window_target(target).await?;
+            if !focus.exact_window_focused {
+                anyhow::bail!(
+                    "the requested window could not be focused exactly; refusing to capture unrelated desktop pixels"
+                );
+            }
+            sleep(Duration::from_millis(250)).await;
+            focus
+                .focused_window
+                .filter(|window| window.window_id == focus.requested_window.window_id)
+                .ok_or_else(|| anyhow::anyhow!("focused-window verification returned no window"))?
+        } else {
+            let windows = list_windows().await?;
+            let window = resolve_window_target(&windows, target)?.clone();
+            if !window.focused {
+                anyhow::bail!(
+                    "raise_window=false requires the requested window to already be focused"
+                );
+            }
+            window
+        };
+        if window.hidden {
+            anyhow::bail!("the requested window is hidden or minimized");
+        }
+        Ok(window)
+    }
+
+    async fn window_crop_rect_for_capture(
+        &self,
+        window: &WindowInfo,
+        raw: &RawScreenshotCapture,
+    ) -> Result<(i32, i32, u32, u32)> {
+        self.window_crop_rect_for_dimensions(window, raw.width, raw.height)
+            .await
+    }
+
+    async fn window_crop_rect_for_dimensions(
+        &self,
+        window: &WindowInfo,
+        capture_width: u32,
+        capture_height: u32,
+    ) -> Result<(i32, i32, u32, u32)> {
+        Ok(self
+            .window_coordinate_map_for_dimensions(window, capture_width, capture_height)
+            .await?
+            .capture_rect)
+    }
+
+    async fn window_coordinate_map_for_dimensions(
+        &self,
+        window: &WindowInfo,
+        capture_width: u32,
+        capture_height: u32,
+    ) -> Result<WindowCoordinateMap> {
+        let bounds = window.bounds.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "targeted screenshot requires window bounds; refusing to return the full desktop"
+            )
+        })?;
+        let logical_rect = window_crop_rect(bounds).ok_or_else(|| {
+            anyhow::anyhow!(
+                "targeted screenshot has unusable window bounds; refusing to return the full desktop"
+            )
+        })?;
+        let monitors = if window.backend == GNOME_SHELL_EXTENSION_BACKEND {
+            Some(
+                crate::windowing::backends::gnome::extension_monitor_layout()
+                    .await
+                    .map_err(|error| {
+                        anyhow::anyhow!(
+                            "GNOME targeted screenshot requires logical monitor geometry: {error:#}"
+                        )
+                    })?,
+            )
+        } else if window.backend == GNOME_SHELL_INTROSPECT_BACKEND {
+            crate::windowing::backends::gnome::extension_monitor_layout()
+                .await
+                .ok()
+        } else {
+            None
+        };
+        let (full_capture_rect, portal_rect) = match monitors {
+            Some(monitors) => (
+                logical_window_crop_rect(bounds, &monitors, capture_width, capture_height)?,
+                Some(logical_rect),
+            ),
+            None => (logical_rect, None),
+        };
+        Ok(WindowCoordinateMap {
+            capture_rect: clip_capture_rect(full_capture_rect, capture_width, capture_height)?,
+            full_capture_rect,
+            portal_rect,
+        })
+    }
+
+    async fn focused_window_coordinate_map(
+        &self,
+        focus: &WindowFocusResult,
+    ) -> std::result::Result<WindowCoordinateMap, String> {
+        let window = focus
+            .focused_window
+            .as_ref()
+            .unwrap_or(&focus.requested_window);
+        if !matches!(
+            window.backend.as_str(),
+            GNOME_SHELL_EXTENSION_BACKEND | GNOME_SHELL_INTROSPECT_BACKEND
+        ) {
+            let full_capture_rect = window
+                .bounds
+                .as_ref()
+                .and_then(window_crop_rect)
+                .ok_or_else(|| {
+                    "Window-relative coordinates require usable target-window bounds.".to_string()
+                })?;
+            let capture_rect = self
+                .desktop_size
+                .lock()
+                .ok()
+                .and_then(|guard| *guard)
+                .map(|(width, height)| {
+                    clip_capture_rect(full_capture_rect, width, height).map_err(|error| {
+                        format!("Could not map target-window coordinates: {error:#}")
+                    })
+                })
+                .transpose()?
+                .unwrap_or(full_capture_rect);
+            return Ok(WindowCoordinateMap {
+                capture_rect,
+                full_capture_rect,
+                portal_rect: None,
+            });
+        }
+        let (_, _, width, height) = self.capture_space_rect().await.ok_or_else(|| {
+            "Could not determine screenshot dimensions for window-relative coordinates.".to_string()
+        })?;
+        self.window_coordinate_map_for_dimensions(window, width as u32, height as u32)
+            .await
+            .map_err(|error| format!("Could not map target-window coordinates: {error:#}"))
     }
 
     async fn resolve_accessibility_app_filter(
@@ -2280,6 +2643,16 @@ impl ComputerUseLinux {
         if let Ok(mut guard) = self.desktop_size.lock() {
             *guard = Some((width, height));
         }
+    }
+
+    fn logical_portal_point(
+        &self,
+        session: &PortalPointerSession,
+        x: i32,
+        y: i32,
+    ) -> Option<(i32, i32)> {
+        let capture_size = self.desktop_size.lock().ok().and_then(|guard| *guard);
+        session.logical_point_from_capture(x, y, capture_size)
     }
 
     /// COORDINATE SPACES: window bounds (list_windows / extension frame rects)
@@ -3135,42 +3508,38 @@ fn data_url_payload(data_url: &str) -> String {
 }
 
 fn session_is_wayland(session_type: Option<&str>, wayland_display: Option<&str>) -> bool {
-    match session_type {
+    match session_type
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
         Some(value) => value.eq_ignore_ascii_case("wayland"),
-        None => wayland_display.is_some_and(|value| !value.is_empty()),
+        None => wayland_display.is_some_and(|value| !value.trim().is_empty()),
     }
+}
+
+fn prefer_xdotool_keyboard(
+    force_ydotool: bool,
+    force_xdotool: bool,
+    is_wayland: bool,
+    display_available: bool,
+    xdotool_available: bool,
+) -> bool {
+    !force_ydotool && display_available && xdotool_available && (force_xdotool || !is_wayland)
 }
 
 fn prepare_app_state_screenshot(
     mut raw: RawScreenshotCapture,
-    bounds: Option<&crate::windowing::WindowBounds>,
+    crop: Option<(i32, i32, u32, u32)>,
     target_requested: bool,
     options: ScreenshotPayloadOptions,
 ) -> Result<ScreenshotCapture> {
-    if target_requested && bounds.is_none() {
+    if target_requested && crop.is_none() {
         anyhow::bail!(
             "targeted screenshot requires a resolved window; refusing to return the full desktop"
         );
     }
-    if let Some(bounds) = bounds {
-        let (mut x, mut y, mut width, mut height) = window_crop_rect(bounds).ok_or_else(|| {
-            anyhow::anyhow!(
-                "targeted screenshot has unusable window bounds; refusing to return the full desktop"
-            )
-        })?;
-        if x < 0 {
-            width = width.saturating_sub(x.unsigned_abs());
-            x = 0;
-        }
-        if y < 0 {
-            height = height.saturating_sub(y.unsigned_abs());
-            y = 0;
-        }
-        if width == 0 || height == 0 {
-            anyhow::bail!(
-                "targeted screenshot window is outside the captured desktop; refusing to return the full desktop"
-            );
-        }
+    if let Some(rect) = crop {
+        let (x, y, width, height) = clip_capture_rect(rect, raw.width, raw.height)?;
         let (bytes, width, height) = crop_png(&raw.bytes, x, y, width, height)
             .map_err(|error| anyhow::anyhow!("targeted screenshot crop failed: {error}"))?;
         raw = RawScreenshotCapture {
@@ -3182,6 +3551,138 @@ fn prepare_app_state_screenshot(
         };
     }
     prepare_screenshot_payload(raw, options)
+}
+
+fn ensure_readonly_screenshot_target_is_visible(window: &WindowInfo) -> Result<()> {
+    if window.hidden {
+        anyhow::bail!("targeted get_app_state screenshot requires a visible, unminimized window");
+    }
+    if !window.focused {
+        anyhow::bail!(
+            "targeted get_app_state screenshot requires the window to already be focused; use the screenshot tool to raise it before capture"
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WindowCoordinateMap {
+    capture_rect: (i32, i32, u32, u32),
+    full_capture_rect: (i32, i32, u32, u32),
+    portal_rect: Option<(i32, i32, u32, u32)>,
+}
+
+impl WindowCoordinateMap {
+    fn portal_point(&self, capture_x: i32, capture_y: i32) -> Option<(i32, i32)> {
+        let (portal_x, portal_y, portal_width, portal_height) = self.portal_rect?;
+        let (full_x, full_y, full_width, full_height) = self.full_capture_rect;
+        Some((
+            map_coordinate_between_rects(capture_x, full_x, full_width, portal_x, portal_width),
+            map_coordinate_between_rects(capture_y, full_y, full_height, portal_y, portal_height),
+        ))
+    }
+}
+
+fn map_coordinate_between_rects(
+    value: i32,
+    source_origin: i32,
+    source_size: u32,
+    target_origin: i32,
+    target_size: u32,
+) -> i32 {
+    let offset = i64::from(value) - i64::from(source_origin);
+    let scaled = offset.saturating_mul(i64::from(target_size)) / i64::from(source_size.max(1));
+    (i64::from(target_origin) + scaled).clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
+}
+
+fn logical_window_crop_rect(
+    bounds: &crate::windowing::WindowBounds,
+    monitors: &[crate::windowing::backends::gnome::MonitorInfo],
+    capture_width: u32,
+    capture_height: u32,
+) -> Result<(i32, i32, u32, u32)> {
+    let mut monitors = monitors
+        .iter()
+        .filter(|monitor| monitor.width > 0 && monitor.height > 0);
+    let first = monitors
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("GNOME returned no usable monitor geometry"))?;
+    let (mut min_x, mut min_y) = (i64::from(first.x), i64::from(first.y));
+    let (mut max_x, mut max_y) = (
+        i64::from(first.x) + i64::from(first.width),
+        i64::from(first.y) + i64::from(first.height),
+    );
+    for monitor in monitors {
+        min_x = min_x.min(i64::from(monitor.x));
+        min_y = min_y.min(i64::from(monitor.y));
+        max_x = max_x.max(i64::from(monitor.x) + i64::from(monitor.width));
+        max_y = max_y.max(i64::from(monitor.y) + i64::from(monitor.height));
+    }
+    let logical_width = max_x - min_x;
+    let logical_height = max_y - min_y;
+    if logical_width <= 0 || logical_height <= 0 || capture_width == 0 || capture_height == 0 {
+        anyhow::bail!("screenshot or monitor geometry is empty");
+    }
+    let scale_x = f64::from(capture_width) / logical_width as f64;
+    let scale_y = f64::from(capture_height) / logical_height as f64;
+    if !scale_x.is_finite() || !scale_y.is_finite() || (scale_x - scale_y).abs() > 0.01 {
+        anyhow::bail!(
+            "captured desktop {}x{} does not have a uniform scale relative to the logical monitor layout {}x{}",
+            capture_width,
+            capture_height,
+            logical_width,
+            logical_height
+        );
+    }
+
+    let x = i64::from(
+        bounds
+            .x
+            .ok_or_else(|| anyhow::anyhow!("window x is unavailable"))?,
+    );
+    let y = i64::from(
+        bounds
+            .y
+            .ok_or_else(|| anyhow::anyhow!("window y is unavailable"))?,
+    );
+    if bounds.width == 0 || bounds.height == 0 {
+        anyhow::bail!("window bounds are empty");
+    }
+    let left = (((x - min_x) as f64) * scale_x).floor() as i64;
+    let top = (((y - min_y) as f64) * scale_y).floor() as i64;
+    let right = (((x + i64::from(bounds.width) - min_x) as f64) * scale_x).ceil() as i64;
+    let bottom = (((y + i64::from(bounds.height) - min_y) as f64) * scale_y).ceil() as i64;
+    let width = u32::try_from(right - left)
+        .map_err(|_| anyhow::anyhow!("scaled window width is invalid"))?;
+    let height = u32::try_from(bottom - top)
+        .map_err(|_| anyhow::anyhow!("scaled window height is invalid"))?;
+    let left = i32::try_from(left).map_err(|_| anyhow::anyhow!("scaled window x is invalid"))?;
+    let top = i32::try_from(top).map_err(|_| anyhow::anyhow!("scaled window y is invalid"))?;
+    Ok((left, top, width, height))
+}
+
+fn clip_capture_rect(
+    (x, y, width, height): (i32, i32, u32, u32),
+    capture_width: u32,
+    capture_height: u32,
+) -> Result<(i32, i32, u32, u32)> {
+    let left = i64::from(x).max(0);
+    let top = i64::from(y).max(0);
+    let right = (i64::from(x) + i64::from(width)).min(i64::from(capture_width));
+    let bottom = (i64::from(y) + i64::from(height)).min(i64::from(capture_height));
+    if right <= left || bottom <= top {
+        anyhow::bail!(
+            "targeted screenshot window is outside the captured desktop; refusing to return the full desktop"
+        );
+    }
+    Ok((
+        i32::try_from(left).map_err(|_| anyhow::anyhow!("capture crop x is invalid"))?,
+        i32::try_from(top).map_err(|_| anyhow::anyhow!("capture crop y is invalid"))?,
+        u32::try_from(right - left)
+            .map_err(|_| anyhow::anyhow!("capture crop width is invalid"))?,
+        u32::try_from(bottom - top)
+            .map_err(|_| anyhow::anyhow!("capture crop height is invalid"))?,
+    ))
 }
 
 /// Convert a window's bounds into a crop rectangle, if it has a usable origin
@@ -3197,21 +3698,14 @@ fn window_crop_rect(bounds: &crate::windowing::WindowBounds) -> Option<(i32, i32
 
 fn apply_window_relative_click_coordinates(
     params: &mut ClickParams,
-    focus: &WindowFocusResult,
+    capture_rect: (i32, i32, u32, u32),
 ) -> std::result::Result<(), String> {
     let (relative_x, relative_y) = params
         .x
         .zip(params.y)
         .ok_or_else(|| "Relative coordinate clicks require both x and y.".to_string())?;
-    let bounds = focus
-        .focused_window
-        .as_ref()
-        .and_then(|window| window.bounds.as_ref())
-        .or(focus.requested_window.bounds.as_ref())
-        .ok_or_else(|| {
-            "Relative coordinate clicks require resolved target-window bounds.".to_string()
-        })?;
-    if bounds.width == 0 || bounds.height == 0 {
+    let (origin_x, origin_y, width, height) = capture_rect;
+    if width == 0 || height == 0 {
         return Err(
             "Relative coordinate clicks require non-empty target-window bounds.".to_string(),
         );
@@ -3219,12 +3713,9 @@ fn apply_window_relative_click_coordinates(
     if relative_x < 0 || relative_y < 0 {
         return Err("Relative click coordinates must be inside target-window bounds.".to_string());
     }
-    if relative_x as u32 >= bounds.width || relative_y as u32 >= bounds.height {
+    if relative_x as u32 >= width || relative_y as u32 >= height {
         return Err("Relative click coordinates must be inside target-window bounds.".to_string());
     }
-    let (origin_x, origin_y) = bounds.x.zip(bounds.y).ok_or_else(|| {
-        "Relative coordinate clicks require target-window bounds with an origin.".to_string()
-    })?;
     let x = origin_x
         .checked_add(relative_x)
         .ok_or_else(|| "Relative click x coordinate overflowed.".to_string())?;
@@ -3241,63 +3732,38 @@ fn apply_window_relative_click_coordinates(
 /// whatever is under the current pointer position.
 fn apply_window_center_scroll_point(
     params: &mut ScrollParams,
-    focus: &WindowFocusResult,
+    capture_rect: (i32, i32, u32, u32),
 ) -> std::result::Result<(), String> {
-    let bounds = focus
-        .focused_window
-        .as_ref()
-        .and_then(|window| window.bounds.as_ref())
-        .or(focus.requested_window.bounds.as_ref())
-        .ok_or_else(|| {
-            "Window-targeted scroll requires resolved target-window bounds; pass x/y explicitly."
-                .to_string()
-        })?;
-    if bounds.width == 0 || bounds.height == 0 {
+    let (origin_x, origin_y, width, height) = capture_rect;
+    if width == 0 || height == 0 {
         return Err(
             "Window-targeted scroll requires non-empty target-window bounds; pass x/y explicitly."
                 .to_string(),
         );
     }
-    let (origin_x, origin_y) = bounds.x.zip(bounds.y).ok_or_else(|| {
-        "Window-targeted scroll requires target-window bounds with an origin; pass x/y explicitly."
-            .to_string()
-    })?;
-    params.x = Some(origin_x.saturating_add((bounds.width / 2) as i32));
-    params.y = Some(origin_y.saturating_add((bounds.height / 2) as i32));
+    params.x = Some(origin_x.saturating_add((width / 2) as i32));
+    params.y = Some(origin_y.saturating_add((height / 2) as i32));
     Ok(())
 }
 
 fn apply_window_relative_scroll_coordinates(
     params: &mut ScrollParams,
-    focus: &WindowFocusResult,
+    capture_rect: (i32, i32, u32, u32),
 ) -> std::result::Result<(), String> {
     let (relative_x, relative_y) = params
         .x
         .zip(params.y)
         .ok_or_else(|| "Relative scroll coordinates require both x and y.".to_string())?;
-    let bounds = focus
-        .focused_window
-        .as_ref()
-        .and_then(|window| window.bounds.as_ref())
-        .or(focus.requested_window.bounds.as_ref())
-        .ok_or_else(|| {
-            "Relative scroll coordinates require resolved target-window bounds.".to_string()
-        })?;
-    if bounds.width == 0 || bounds.height == 0 {
+    let (origin_x, origin_y, width, height) = capture_rect;
+    if width == 0 || height == 0 {
         return Err(
             "Relative scroll coordinates require non-empty target-window bounds.".to_string(),
         );
     }
-    if relative_x < 0
-        || relative_y < 0
-        || relative_x as u32 >= bounds.width
-        || relative_y as u32 >= bounds.height
+    if relative_x < 0 || relative_y < 0 || relative_x as u32 >= width || relative_y as u32 >= height
     {
         return Err("Relative scroll coordinates must be inside target-window bounds.".to_string());
     }
-    let (origin_x, origin_y) = bounds.x.zip(bounds.y).ok_or_else(|| {
-        "Relative scroll coordinates require target-window bounds with an origin.".to_string()
-    })?;
     params.x = Some(origin_x.saturating_add(relative_x));
     params.y = Some(origin_y.saturating_add(relative_y));
     Ok(())
@@ -3350,6 +3816,34 @@ fn action_result(
             message,
             received,
         },
+    }
+}
+
+fn portal_action_error(
+    action: &str,
+    error: anyhow::Error,
+    received: Option<serde_json::Value>,
+) -> ActionOutput {
+    ActionOutput {
+        ok: false,
+        implemented: true,
+        action: action.to_string(),
+        message: format!(
+            "Remote desktop portal {action} may have started before it failed; input was not replayed through another backend: {error:#}"
+        ),
+        received,
+    }
+}
+
+fn portal_coordinate_error(action: &str, received: Option<serde_json::Value>) -> ActionOutput {
+    ActionOutput {
+        ok: false,
+        implemented: true,
+        action: action.to_string(),
+        message: format!(
+            "Remote desktop portal {action} was not sent because the coordinate could not be mapped safely to the complete shared desktop; input was not replayed through another backend."
+        ),
+        received,
     }
 }
 
@@ -3505,102 +3999,56 @@ async fn run_ydotool_sequence(
 }
 
 async fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
-    let mut command = TokioCommand::new("ydotool");
+    let support = ydotool::ensure_supported_async().await?;
+    let mut command = TokioCommand::new(&support.executable);
     command.args(args);
     if let Some(socket) = ydotool_socket() {
         command.env("YDOTOOL_SOCKET", socket);
     }
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-
-    match command.spawn() {
-        Ok(child) => match wait_for_ydotool_output(child).await {
-            Ok(output) if output.status.success() => Ok(output),
-            Ok(output) => Err(ydotool_output_error(output)),
-            Err(error) => Err(error),
-        },
-        Err(error) => Err(format!("failed to run ydotool: {error}")),
+    let output =
+        crate::command_runner::output_with_timeout(command, "run ydotool", INPUT_COMMAND_TIMEOUT)
+            .await
+            .map_err(|error| format!("{error:#}"))?;
+    if output.status.success() {
+        if let Some(error) = ydotool::cli_error(&output.stderr) {
+            Err(error)
+        } else {
+            Ok(output)
+        }
+    } else {
+        Err(ydotool_output_error(output))
     }
 }
 
 async fn run_ydotool_type_text(text: &str) -> std::result::Result<Output, String> {
-    let mut command = TokioCommand::new("ydotool");
+    let support = ydotool::ensure_supported_async().await?;
+    let mut command = TokioCommand::new(&support.executable);
     command.args(["type", "--file", "-"]);
     if let Some(socket) = ydotool_socket() {
         command.env("YDOTOOL_SOCKET", socket);
     }
-    command.stdin(Stdio::piped());
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-
-    match command.spawn() {
-        Ok(mut child) => {
-            if let Some(mut stdin) = child.stdin.take() {
-                if let Err(error) = stdin.write_all(text.as_bytes()).await {
-                    let _ = child.kill().await;
-                    return Err(format!("failed to write text to ydotool stdin: {error}"));
-                }
-            }
-            let output =
-                wait_for_ydotool_output_with_timeout(child, ydotool_type_timeout(text)).await?;
-            if output.status.success() {
-                Ok(output)
-            } else {
-                Err(ydotool_output_error(output))
-            }
+    let output = crate::command_runner::output_with_stdin(
+        command,
+        "run ydotool type",
+        ydotool_type_timeout(text),
+        text.as_bytes().to_vec(),
+    )
+    .await
+    .map_err(|error| format!("{error:#}"))?;
+    if output.status.success() {
+        if let Some(error) = ydotool::cli_error(&output.stderr) {
+            Err(error)
+        } else {
+            Ok(output)
         }
-        Err(error) => Err(format!("failed to run ydotool: {error}")),
+    } else {
+        Err(ydotool_output_error(output))
     }
-}
-
-async fn wait_for_ydotool_output(child: TokioChild) -> std::result::Result<Output, String> {
-    wait_for_ydotool_output_with_timeout(child, YDOTOOL_TIMEOUT).await
-}
-
-async fn wait_for_ydotool_output_with_timeout(
-    mut child: TokioChild,
-    timeout_duration: Duration,
-) -> std::result::Result<Output, String> {
-    let stdout_reader = read_child_pipe(child.stdout.take());
-    let stderr_reader = read_child_pipe(child.stderr.take());
-    let status = match timeout(timeout_duration, child.wait()).await {
-        Err(_) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            stdout_reader.abort();
-            stderr_reader.abort();
-            return Err(format!(
-                "ydotool timed out after {}s",
-                timeout_duration.as_secs()
-            ));
-        }
-        Ok(result) => result.map_err(|error| format!("failed to wait for ydotool: {error}"))?,
-    };
-    let stdout = stdout_reader.await.unwrap_or_default();
-    let stderr = stderr_reader.await.unwrap_or_default();
-    Ok(Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
-
-fn read_child_pipe<R>(pipe: Option<R>) -> tokio::task::JoinHandle<Vec<u8>>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-{
-    tokio::spawn(async move {
-        let mut output = Vec::new();
-        if let Some(mut pipe) = pipe {
-            let _ = pipe.read_to_end(&mut output).await;
-        }
-        output
-    })
 }
 
 fn ydotool_type_timeout(text: &str) -> Duration {
     let text_seconds = (text.chars().count() as u64).div_ceil(YDOTOOL_TYPE_CHARS_PER_SECOND);
-    Duration::from_secs(YDOTOOL_TIMEOUT.as_secs().saturating_add(text_seconds))
+    Duration::from_secs(INPUT_COMMAND_TIMEOUT.as_secs().saturating_add(text_seconds))
 }
 
 const EVDEV_KEY_LEFTCTRL: i32 = 29;
@@ -3752,19 +4200,63 @@ fn ydotool_output_error(output: Output) -> String {
 /// named keys and chords land as unrelated glyphs and literal text can mangle
 /// symbols/digits (`_` → `%`, `1` → `+`). XTEST resolves keysyms against the
 /// live layout, which is what X11 clients actually expect. See issue #58.
-async fn run_xdotool(args: &[String]) -> std::result::Result<Output, String> {
-    let mut command = TokioCommand::new("xdotool");
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyboardCommandBackend {
+    Xdotool,
+    Ydotool,
+}
+
+struct KeyboardCommandResult {
+    output: Output,
+    backend: KeyboardCommandBackend,
+}
+
+enum XdotoolAttempt {
+    Unavailable,
+    Finished(std::result::Result<Output, String>),
+}
+
+async fn run_xdotool(program: &Path, args: &[String]) -> XdotoolAttempt {
+    let mut command = TokioCommand::new(program);
     command.args(args);
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
+    command.kill_on_drop(true);
+    command.process_group(0);
 
     match command.spawn() {
-        Ok(child) => match wait_for_ydotool_output(child).await {
-            Ok(output) if output.status.success() => Ok(output),
-            Ok(output) => Err(command_output_error("xdotool", output)),
-            Err(error) => Err(error),
-        },
-        Err(error) => Err(format!("failed to run xdotool: {error}")),
+        Ok(child) => XdotoolAttempt::Finished(
+            match crate::command_runner::output_child(child, "run xdotool", INPUT_COMMAND_TIMEOUT)
+                .await
+                .map_err(|error| format!("{error:#}"))
+            {
+                Ok(output) if output.status.success() => Ok(output),
+                Ok(output) => Err(command_output_error("xdotool", output)),
+                Err(error) => Err(error),
+            },
+        ),
+        Err(_) => XdotoolAttempt::Unavailable,
+    }
+}
+
+async fn run_xdotool_or_fallback<F, Fut>(
+    program: &Path,
+    args: &[String],
+    fallback: F,
+) -> std::result::Result<KeyboardCommandResult, String>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = std::result::Result<Output, String>>,
+{
+    match run_xdotool(program, args).await {
+        XdotoolAttempt::Unavailable => fallback().await.map(|output| KeyboardCommandResult {
+            output,
+            backend: KeyboardCommandBackend::Ydotool,
+        }),
+        XdotoolAttempt::Finished(result) => result.map(|output| KeyboardCommandResult {
+            output,
+            backend: KeyboardCommandBackend::Xdotool,
+        }),
     }
 }
 
@@ -3773,6 +4265,17 @@ async fn run_xdotool(args: &[String]) -> std::result::Result<Output, String> {
 /// opts out; `COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD=1` forces it on.
 fn xdotool_available() -> bool {
     which_in_path("xdotool")
+}
+
+fn xdotool_type_args(text: &str) -> Vec<String> {
+    vec![
+        "type".to_string(),
+        "--clearmodifiers".to_string(),
+        "--delay".to_string(),
+        "0".to_string(),
+        "--".to_string(),
+        text.to_string(),
+    ]
 }
 
 fn which_in_path(binary: &str) -> bool {
@@ -3894,6 +4397,28 @@ fn ydotool_socket() -> Option<String> {
         .map(|path| path.display().to_string())
 }
 
+async fn ydotool_backend_available() -> bool {
+    ydotool_backend_available_from(
+        ydotool_socket_connectable(),
+        ydotool::ensure_supported_async().await.is_ok(),
+    )
+}
+
+fn ydotool_socket_connectable() -> bool {
+    if let Some(socket) = explicit_ydotool_socket() {
+        return ydotool_socket_connects(&PathBuf::from(socket));
+    }
+    connectable_ydotool_socket_from(fallback_ydotool_socket_candidates()).is_some()
+}
+
+fn ydotool_backend_available_from(socket_available: bool, cli_supported: bool) -> bool {
+    socket_available && cli_supported
+}
+
+fn should_prefer_portal_backend_by_default(is_wayland: bool, ydotool_available: bool) -> bool {
+    is_wayland && !ydotool_available
+}
+
 fn explicit_ydotool_socket() -> Option<String> {
     if let Ok(socket) = env::var("YDOTOOL_SOCKET") {
         let socket = socket.trim();
@@ -3922,10 +4447,9 @@ fn connectable_ydotool_socket_from(candidates: Vec<PathBuf>) -> Option<PathBuf> 
 }
 
 fn ydotool_socket_connects(path: &PathBuf) -> bool {
-    UnixStream::connect(path).is_ok()
-        || UnixDatagram::unbound()
-            .and_then(|socket| socket.connect(path))
-            .is_ok()
+    UnixDatagram::unbound()
+        .and_then(|socket| socket.connect(path))
+        .is_ok()
 }
 
 fn mouse_button_code(button: Option<&str>) -> String {
@@ -4141,6 +4665,7 @@ mod tests {
     use super::*;
     use crate::atspi_tree::{AccessibilityAction, Bounds};
     use crate::windows::{WindowBounds, GNOME_SHELL_EXTENSION_BACKEND};
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn exported_tool_schemas_omit_unsigned_integer_formats() {
@@ -4239,15 +4764,9 @@ mod tests {
             width: 400,
             height: 200,
         };
-        let bounds = WindowBounds {
-            x: Some(50),
-            y: Some(20),
-            width: 200,
-            height: 100,
-        };
         let capture = prepare_app_state_screenshot(
             raw,
-            Some(&bounds),
+            Some((50, 20, 200, 100)),
             true,
             ScreenshotPayloadOptions {
                 max_width: Some(100),
@@ -4291,16 +4810,9 @@ mod tests {
             width: 400,
             height: 200,
         };
-        let bounds = WindowBounds {
-            x: Some(-50),
-            y: Some(-40),
-            width: 100,
-            height: 100,
-        };
-
         let capture = prepare_app_state_screenshot(
             raw,
-            Some(&bounds),
+            Some((-50, -40, 100, 100)),
             true,
             ScreenshotPayloadOptions::default(),
         )
@@ -4313,10 +4825,126 @@ mod tests {
     }
 
     #[test]
+    fn gnome_window_crop_scales_logical_bounds_to_capture_pixels() {
+        let bounds = WindowBounds {
+            x: Some(6),
+            y: Some(36),
+            width: 1357,
+            height: 1144,
+        };
+        let monitors = [crate::windowing::backends::gnome::MonitorInfo {
+            index: 0,
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1200,
+            primary: true,
+            scale: 4.0 / 3.0,
+        }];
+
+        assert_eq!(
+            logical_window_crop_rect(&bounds, &monitors, 2560, 1600).unwrap(),
+            (8, 48, 1810, 1526)
+        );
+    }
+
+    #[test]
+    fn portal_points_map_capture_pixels_back_to_logical_window_space() {
+        let scaled = WindowCoordinateMap {
+            capture_rect: (8, 48, 1810, 1526),
+            full_capture_rect: (8, 48, 1810, 1526),
+            portal_rect: Some((6, 36, 1357, 1144)),
+        };
+        assert_eq!(scaled.portal_point(913, 811), Some((684, 608)));
+
+        let clipped = WindowCoordinateMap {
+            capture_rect: (0, 0, 50, 60),
+            full_capture_rect: (-50, -40, 100, 100),
+            portal_rect: Some((-50, -40, 100, 100)),
+        };
+        assert_eq!(clipped.portal_point(0, 0), Some((0, 0)));
+    }
+
+    #[test]
+    fn gnome_window_crop_accounts_for_negative_monitor_origins() {
+        let bounds = WindowBounds {
+            x: Some(-900),
+            y: Some(100),
+            width: 400,
+            height: 300,
+        };
+        let monitors = [
+            crate::windowing::backends::gnome::MonitorInfo {
+                index: 0,
+                x: -1000,
+                y: 0,
+                width: 1000,
+                height: 800,
+                primary: false,
+                scale: 1.0,
+            },
+            crate::windowing::backends::gnome::MonitorInfo {
+                index: 1,
+                x: 0,
+                y: 0,
+                width: 1200,
+                height: 800,
+                primary: true,
+                scale: 1.0,
+            },
+        ];
+
+        assert_eq!(
+            logical_window_crop_rect(&bounds, &monitors, 2200, 800).unwrap(),
+            (100, 100, 400, 300)
+        );
+    }
+
+    #[test]
+    fn readonly_targeted_screenshot_requires_focused_visible_window() {
+        let mut window = window_info(1, Some("Target"), None, None, None);
+        assert!(ensure_readonly_screenshot_target_is_visible(&window).is_err());
+        window.focused = true;
+        assert!(ensure_readonly_screenshot_target_is_visible(&window).is_ok());
+        window.hidden = true;
+        assert!(ensure_readonly_screenshot_target_is_visible(&window).is_err());
+    }
+
+    #[test]
     fn wayland_display_is_enough_to_select_portal_fallback() {
         assert!(session_is_wayland(None, Some("wayland-1")));
+        assert!(session_is_wayland(Some("  "), Some("wayland-1")));
         assert!(session_is_wayland(Some("wayland"), None));
         assert!(!session_is_wayland(Some("x11"), None));
+        assert!(!session_is_wayland(None, Some("  ")));
+    }
+
+    #[test]
+    fn incompatible_ydotool_socket_does_not_suppress_portal_fallback() {
+        let incompatible_ydotool = ydotool_backend_available_from(true, false);
+        let compatible_ydotool = ydotool_backend_available_from(true, true);
+
+        assert!(should_prefer_portal_backend_by_default(
+            true,
+            incompatible_ydotool
+        ));
+        assert!(!should_prefer_portal_backend_by_default(
+            true,
+            compatible_ydotool
+        ));
+        assert!(!should_prefer_portal_backend_by_default(
+            false,
+            incompatible_ydotool
+        ));
+    }
+
+    #[test]
+    fn xdotool_keyboard_override_policy_matches_documented_precedence() {
+        assert!(prefer_xdotool_keyboard(false, true, true, true, true));
+        assert!(!prefer_xdotool_keyboard(true, true, true, true, true));
+        assert!(!prefer_xdotool_keyboard(false, true, true, false, true));
+        assert!(!prefer_xdotool_keyboard(false, false, true, true, true));
+        assert!(prefer_xdotool_keyboard(false, false, false, true, true));
     }
 
     #[test]
@@ -4375,39 +5003,8 @@ mod tests {
         }
     }
 
-    fn focus_result_with_bounds(bounds: Option<WindowBounds>) -> WindowFocusResult {
-        let mut requested_window = window_info(
-            42,
-            Some("Target"),
-            Some("target-app"),
-            Some("target-app"),
-            Some(4242),
-        );
-        requested_window.bounds = bounds;
-        let mut focused_window = requested_window.clone();
-        focused_window.focused = true;
-        WindowFocusResult {
-            requested_window,
-            focused_window: Some(focused_window),
-            exact_window_focused: true,
-            app_focused: true,
-            backend: GNOME_SHELL_EXTENSION_BACKEND.to_string(),
-            note: "test focus".to_string(),
-        }
-    }
-
-    fn window_bounds(x: Option<i32>, y: Option<i32>, width: u32, height: u32) -> WindowBounds {
-        WindowBounds {
-            x,
-            y,
-            width,
-            height,
-        }
-    }
-
     #[test]
-    fn relative_click_coordinates_use_verified_window_bounds() {
-        let focus = focus_result_with_bounds(Some(window_bounds(Some(100), Some(200), 800, 600)));
+    fn relative_click_coordinates_use_capture_space_rect() {
         let mut params = ClickParams {
             x: Some(7),
             y: Some(9),
@@ -4415,58 +5012,21 @@ mod tests {
             ..Default::default()
         };
 
-        apply_window_relative_click_coordinates(&mut params, &focus).unwrap();
+        apply_window_relative_click_coordinates(&mut params, (133, 267, 1067, 800)).unwrap();
 
-        assert_eq!((params.x, params.y), (Some(107), Some(209)));
-    }
-
-    #[test]
-    fn relative_click_coordinates_prefer_focused_window_bounds() {
-        let mut focus =
-            focus_result_with_bounds(Some(window_bounds(Some(100), Some(200), 800, 600)));
-        let focused_window = focus
-            .focused_window
-            .as_mut()
-            .expect("test focus should include focused window");
-        focused_window.bounds = Some(window_bounds(Some(300), Some(400), 800, 600));
-        let mut params = ClickParams {
-            x: Some(7),
-            y: Some(9),
-            relative: Some(true),
-            ..Default::default()
-        };
-
-        apply_window_relative_click_coordinates(&mut params, &focus).unwrap();
-
-        assert_eq!((params.x, params.y), (Some(307), Some(409)));
-    }
-
-    #[test]
-    fn relative_click_coordinates_require_window_bounds_origin() {
-        let focus = focus_result_with_bounds(Some(window_bounds(None, Some(200), 800, 600)));
-        let mut params = ClickParams {
-            x: Some(7),
-            y: Some(9),
-            relative: Some(true),
-            ..Default::default()
-        };
-
-        let error = apply_window_relative_click_coordinates(&mut params, &focus).unwrap_err();
-
-        assert!(error.contains("bounds with an origin"));
-        assert_eq!((params.x, params.y), (Some(7), Some(9)));
+        assert_eq!((params.x, params.y), (Some(140), Some(276)));
     }
 
     #[test]
     fn relative_click_coordinates_require_xy() {
-        let focus = focus_result_with_bounds(Some(window_bounds(Some(100), Some(200), 800, 600)));
         let mut params = ClickParams {
             x: Some(7),
             relative: Some(true),
             ..Default::default()
         };
 
-        let error = apply_window_relative_click_coordinates(&mut params, &focus).unwrap_err();
+        let error =
+            apply_window_relative_click_coordinates(&mut params, (100, 200, 800, 600)).unwrap_err();
 
         assert!(error.contains("both x and y"));
         assert_eq!((params.x, params.y), (Some(7), None));
@@ -4474,8 +5034,6 @@ mod tests {
 
     #[test]
     fn relative_click_coordinates_must_stay_inside_bounds() {
-        let focus = focus_result_with_bounds(Some(window_bounds(Some(100), Some(200), 800, 600)));
-
         for (x, y) in [(-1, 9), (7, -1), (800, 9), (7, 600)] {
             let mut params = ClickParams {
                 x: Some(x),
@@ -4484,7 +5042,8 @@ mod tests {
                 ..Default::default()
             };
 
-            let error = apply_window_relative_click_coordinates(&mut params, &focus).unwrap_err();
+            let error = apply_window_relative_click_coordinates(&mut params, (100, 200, 800, 600))
+                .unwrap_err();
 
             assert!(error.contains("inside target-window bounds"));
             assert_eq!((params.x, params.y), (Some(x), Some(y)));
@@ -5069,6 +5628,128 @@ mod tests {
         assert_eq!(xdotool_key_spec("ctrl"), Some("ctrl".to_string()));
     }
 
+    #[test]
+    fn xdotool_type_disables_per_character_delay_for_long_input() {
+        let text = "x".repeat(10_000);
+        let args = xdotool_type_args(&text);
+
+        assert_eq!(
+            &args[..5],
+            ["type", "--clearmodifiers", "--delay", "0", "--"]
+        );
+        assert_eq!(args[5], text);
+    }
+
+    #[tokio::test]
+    async fn launched_xdotool_failure_does_not_replay_through_ydotool() {
+        let dir = std::env::temp_dir().join(format!(
+            "computer-use-linux-xdotool-fallback-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+        ));
+        std::fs::create_dir_all(&dir).expect("create command test directory");
+        let ydotool = dir.join("ydotool");
+        let xdotool_marker = dir.join("xdotool-ran");
+        let ydotool_marker = dir.join("ydotool-ran");
+        std::fs::write(
+            &ydotool,
+            format!("#!/bin/sh\ntouch '{}'\n", ydotool_marker.display()),
+        )
+        .expect("write fake ydotool");
+        std::fs::set_permissions(&ydotool, std::fs::Permissions::from_mode(0o700))
+            .expect("make fake ydotool executable");
+        let xdotool_args = vec![
+            "-c".to_string(),
+            format!("touch '{}'; exit 9", xdotool_marker.display()),
+        ];
+
+        let result = run_xdotool_or_fallback(Path::new("/bin/sh"), &xdotool_args, || async {
+            TokioCommand::new(&ydotool)
+                .output()
+                .await
+                .map_err(|error| error.to_string())
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(xdotool_marker.exists(), "fake xdotool did not execute");
+        assert!(
+            !ydotool_marker.exists(),
+            "ydotool replayed input after xdotool started"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn unavailable_xdotool_uses_ydotool_fallback() {
+        let result = run_xdotool_or_fallback(
+            Path::new("/definitely/missing/xdotool"),
+            &xdotool_type_args("text"),
+            || async {
+                TokioCommand::new("sh")
+                    .args(["-c", "exit 0"])
+                    .output()
+                    .await
+                    .map_err(|error| error.to_string())
+            },
+        )
+        .await
+        .expect("spawn failure should use fallback");
+
+        assert_eq!(result.backend, KeyboardCommandBackend::Ydotool);
+        assert!(result.output.status.success());
+    }
+
+    #[tokio::test]
+    async fn cancelling_xdotool_wait_kills_the_child() {
+        let dir = std::env::temp_dir().join(format!(
+            "computer-use-linux-xdotool-cancel-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+        ));
+        std::fs::create_dir_all(&dir).expect("create command test directory");
+        let xdotool = dir.join("xdotool");
+        let pid_path = dir.join("pid");
+        std::fs::write(
+            &xdotool,
+            format!(
+                "#!/bin/sh\nprintf '%s' $$ > '{}'\nexec sleep 60\n",
+                pid_path.display()
+            ),
+        )
+        .expect("write fake xdotool");
+        std::fs::set_permissions(&xdotool, std::fs::Permissions::from_mode(0o700))
+            .expect("make fake xdotool executable");
+
+        let task = tokio::spawn(async move { run_xdotool(&xdotool, &[]).await });
+        let mut pid = None;
+        for _ in 0..50 {
+            if let Ok(value) = std::fs::read_to_string(&pid_path) {
+                pid = value.parse::<u32>().ok();
+                if pid.is_some() {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let pid = pid.expect("fake xdotool did not record its pid");
+        task.abort();
+        let _ = task.await;
+
+        for _ in 0..50 {
+            if !Path::new(&format!("/proc/{pid}")).exists() {
+                let _ = std::fs::remove_dir_all(dir);
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        let _ = std::fs::remove_dir_all(dir);
+        panic!("cancelled xdotool child {pid} was not killed");
+    }
+
     /// The xdotool path must accept exactly the keys the evdev grammar accepts,
     /// so switching backends can never silently widen or narrow the surface.
     #[test]
@@ -5116,14 +5797,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ydotool_wait_drains_output_before_exit() {
+    async fn command_wait_drains_output_before_exit() {
         let mut command = tokio::process::Command::new("sh");
         command.args(["-c", "yes noisy | head -c 200000 >&2; exit 7"]);
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
 
-        let output = wait_for_ydotool_output_with_timeout(
-            command.spawn().expect("spawn noisy child"),
+        let output = crate::command_runner::output_with_timeout(
+            command,
+            "run test command",
             Duration::from_secs(5),
         )
         .await
@@ -5134,7 +5816,7 @@ mod tests {
     }
 
     #[test]
-    fn ydotool_socket_selection_skips_unconnectable_candidates() {
+    fn ydotool_socket_selection_rejects_legacy_stream_socket() {
         let dir =
             std::env::temp_dir().join(format!("computer-use-linux-server-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
@@ -5145,10 +5827,9 @@ mod tests {
         let listener =
             std::os::unix::net::UnixListener::bind(&usable_socket).expect("bind usable socket");
 
-        let selected = connectable_ydotool_socket_from(vec![stale_socket, usable_socket.clone()])
-            .expect("usable socket should be selected");
+        let selected = connectable_ydotool_socket_from(vec![stale_socket, usable_socket.clone()]);
 
-        assert_eq!(selected, usable_socket);
+        assert!(selected.is_none());
         drop(listener);
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -5419,15 +6100,7 @@ mod tests {
             window_title: None,
             relative: Some(true),
         };
-        let focus = WindowFocusResult {
-            requested_window: window_with_bounds(1, 100, 200, 800, 600),
-            focused_window: None,
-            app_focused: true,
-            exact_window_focused: true,
-            backend: "test".to_string(),
-            note: String::new(),
-        };
-        apply_window_relative_scroll_coordinates(&mut params, &focus).unwrap();
+        apply_window_relative_scroll_coordinates(&mut params, (100, 200, 800, 600)).unwrap();
         assert_eq!(params.x, Some(110));
         assert_eq!(params.y, Some(220));
     }
@@ -5447,21 +6120,13 @@ mod tests {
             window_title: None,
             relative: None,
         };
-        let focus = WindowFocusResult {
-            requested_window: window_with_bounds(1, 100, 200, 800, 600),
-            focused_window: None,
-            app_focused: true,
-            exact_window_focused: true,
-            backend: "test".to_string(),
-            note: String::new(),
-        };
-        apply_window_center_scroll_point(&mut params, &focus).unwrap();
+        apply_window_center_scroll_point(&mut params, (100, 200, 800, 600)).unwrap();
         assert_eq!(params.x, Some(500));
         assert_eq!(params.y, Some(500));
     }
 
     #[test]
-    fn window_targeted_scroll_without_bounds_errors() {
+    fn window_targeted_scroll_with_empty_capture_rect_errors() {
         let mut params = ScrollParams {
             element_index: None,
             x: None,
@@ -5475,17 +6140,7 @@ mod tests {
             window_title: None,
             relative: None,
         };
-        let mut window = window_with_bounds(1, 0, 0, 1, 1);
-        window.bounds = None;
-        let focus = WindowFocusResult {
-            requested_window: window,
-            focused_window: None,
-            app_focused: true,
-            exact_window_focused: true,
-            backend: "test".to_string(),
-            note: String::new(),
-        };
-        let error = apply_window_center_scroll_point(&mut params, &focus).unwrap_err();
+        let error = apply_window_center_scroll_point(&mut params, (0, 0, 0, 0)).unwrap_err();
         assert!(error.contains("pass x/y explicitly"));
         assert_eq!(params.x, None);
         assert_eq!(params.y, None);
@@ -5506,36 +6161,8 @@ mod tests {
             window_title: None,
             relative: Some(true),
         };
-        let focus = WindowFocusResult {
-            requested_window: window_with_bounds(1, 100, 200, 800, 600),
-            focused_window: None,
-            app_focused: true,
-            exact_window_focused: true,
-            backend: "test".to_string(),
-            note: String::new(),
-        };
-        assert!(apply_window_relative_scroll_coordinates(&mut params, &focus).is_err());
-    }
-
-    fn window_with_bounds(id: u64, x: i32, y: i32, width: u32, height: u32) -> WindowInfo {
-        WindowInfo {
-            window_id: id,
-            title: None,
-            app_id: None,
-            wm_class: None,
-            pid: None,
-            bounds: Some(crate::windowing::WindowBounds {
-                x: Some(x),
-                y: Some(y),
-                width,
-                height,
-            }),
-            workspace: None,
-            focused: true,
-            hidden: false,
-            client_type: None,
-            backend: "test".to_string(),
-            terminal: None,
-        }
+        assert!(
+            apply_window_relative_scroll_coordinates(&mut params, (100, 200, 800, 600)).is_err()
+        );
     }
 }

--- a/src/windowing/backends/cosmic.rs
+++ b/src/windowing/backends/cosmic.rs
@@ -27,8 +27,8 @@ pub fn probe() -> BackendProbe {
     }
 }
 
-pub fn list_windows() -> Result<Vec<WindowInfo>> {
-    let json = cosmic_helper::list_windows_json()?;
+pub async fn list_windows() -> Result<Vec<WindowInfo>> {
+    let json = cosmic_helper::list_windows_json().await?;
     let mut windows: Vec<WindowInfo> =
         serde_json::from_str(&json).context("COSMIC helper returned invalid list-windows JSON")?;
     for window in &mut windows {
@@ -39,8 +39,8 @@ pub fn list_windows() -> Result<Vec<WindowInfo>> {
     Ok(windows)
 }
 
-pub fn focused_window() -> Result<Option<WindowInfo>> {
-    let json = cosmic_helper::focused_window_json()?;
+pub async fn focused_window() -> Result<Option<WindowInfo>> {
+    let json = cosmic_helper::focused_window_json().await?;
     let mut window: Option<WindowInfo> = serde_json::from_str(&json)
         .context("COSMIC helper returned invalid focused-window JSON")?;
     if let Some(window) = window.as_mut() {
@@ -49,8 +49,8 @@ pub fn focused_window() -> Result<Option<WindowInfo>> {
     Ok(window)
 }
 
-pub fn activate_window(window_id: u64) -> Result<()> {
-    let activation = cosmic_helper::activate_window(window_id)?;
+pub async fn activate_window(window_id: u64) -> Result<()> {
+    let activation = cosmic_helper::activate_window(window_id).await?;
     if activation.ok {
         Ok(())
     } else {

--- a/src/windowing/backends/hyprland.rs
+++ b/src/windowing/backends/hyprland.rs
@@ -1,3 +1,4 @@
+use crate::command_runner;
 use crate::terminal::enrich_terminal_windows;
 use crate::windowing::registry::BackendProbe;
 use crate::windowing::types::{WindowBounds, WindowInfo};
@@ -6,8 +7,9 @@ use serde::Deserialize;
 use std::fs;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::Command as StdCommand;
 use std::time::SystemTime;
+use tokio::process::Command;
 
 pub const HYPRLAND_BACKEND: &str = "hyprland";
 
@@ -55,8 +57,10 @@ pub fn probe() -> BackendProbe {
     }
 }
 
-pub fn list_windows() -> Result<Vec<WindowInfo>> {
-    let output = hyprctl_output(&["clients", "-j"]).context("failed to run hyprctl clients -j")?;
+pub async fn list_windows() -> Result<Vec<WindowInfo>> {
+    let output = hyprctl_output_async(&["clients", "-j"])
+        .await
+        .context("failed to run hyprctl clients -j")?;
     if !output.status.success() {
         bail!(
             "hyprctl clients -j failed: {}",
@@ -65,7 +69,7 @@ pub fn list_windows() -> Result<Vec<WindowInfo>> {
     }
 
     let clients_json = String::from_utf8_lossy(&output.stdout);
-    let monitors_output = hyprctl_output(&["monitors", "-j"]).ok();
+    let monitors_output = hyprctl_output_async(&["monitors", "-j"]).await.ok();
     match monitors_output.filter(|output| output.status.success()) {
         Some(monitors) => parse_hyprland_clients_with_monitors(&clients_json, &monitors.stdout),
         None => parse_hyprland_clients(&clients_json),
@@ -125,16 +129,18 @@ fn windows_from_hyprland_clients(clients: Vec<HyprlandClient>) -> Result<Vec<Win
     Ok(windows)
 }
 
-pub fn activate_window(window_id: u64) -> Result<()> {
+pub async fn activate_window(window_id: u64) -> Result<()> {
     let address = format!("address:0x{window_id:x}");
     let lua_dispatch = lua_focus_dispatch(&address);
-    let lua_output = hyprctl_output(&["dispatch", &lua_dispatch])
+    let lua_output = hyprctl_output_async(&["dispatch", &lua_dispatch])
+        .await
         .with_context(|| format!("failed to run Hyprland Lua focus dispatcher for {address}"))?;
     if dispatch_succeeded(&lua_output) {
         return Ok(());
     }
 
-    let legacy_output = hyprctl_output(&["dispatch", "focuswindow", &address])
+    let legacy_output = hyprctl_output_async(&["dispatch", "focuswindow", &address])
+        .await
         .with_context(|| format!("failed to run hyprctl dispatch focuswindow {address}"))?;
     if dispatch_succeeded(&legacy_output) {
         Ok(())
@@ -171,7 +177,7 @@ fn lua_focus_dispatch(address: &str) -> String {
 }
 
 fn hyprctl_output(args: &[&str]) -> std::io::Result<std::process::Output> {
-    let mut command = Command::new("hyprctl");
+    let mut command = StdCommand::new("hyprctl");
     let has_signature = std::env::var("HYPRLAND_INSTANCE_SIGNATURE")
         .ok()
         .is_some_and(|value| !value.trim().is_empty());
@@ -181,6 +187,20 @@ fn hyprctl_output(args: &[&str]) -> std::io::Result<std::process::Output> {
         }
     }
     command.args(args).output()
+}
+
+async fn hyprctl_output_async(args: &[&str]) -> Result<std::process::Output> {
+    let mut command = Command::new("hyprctl");
+    let has_signature = std::env::var("HYPRLAND_INSTANCE_SIGNATURE")
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty());
+    if !has_signature {
+        if let Some(signature) = infer_hyprland_instance_signature() {
+            command.args(["-i", &signature]);
+        }
+    }
+    command.args(args);
+    command_runner::output(command, "run hyprctl").await
 }
 
 fn infer_hyprland_instance_signature() -> Option<String> {

--- a/src/windowing/backends/i3.rs
+++ b/src/windowing/backends/i3.rs
@@ -1,9 +1,11 @@
+use crate::command_runner;
 use crate::terminal::enrich_terminal_windows;
 use crate::windowing::registry::BackendProbe;
 use crate::windowing::types::{WindowBounds, WindowInfo};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::{env, fs, os::unix::fs::FileTypeExt, path::PathBuf, process::Command};
+use tokio::process::Command as TokioCommand;
 
 pub const I3_BACKEND: &str = "i3";
 
@@ -51,11 +53,10 @@ pub fn probe() -> BackendProbe {
     }
 }
 
-pub fn list_windows() -> Result<Vec<WindowInfo>> {
-    let output = i3_msg_command()
-        .args(["-t", "get_tree"])
-        .output()
-        .context("failed to run i3-msg -t get_tree")?;
+pub async fn list_windows() -> Result<Vec<WindowInfo>> {
+    let mut command = i3_msg_command_async();
+    command.args(["-t", "get_tree"]);
+    let output = command_runner::output(command, "run i3-msg -t get_tree").await?;
     if !output.status.success() {
         bail!(
             "i3-msg -t get_tree failed: {}",
@@ -64,7 +65,7 @@ pub fn list_windows() -> Result<Vec<WindowInfo>> {
     }
 
     let mut windows = parse_i3_tree(&String::from_utf8_lossy(&output.stdout))?;
-    hydrate_i3_window_pids(&mut windows);
+    hydrate_i3_window_pids(&mut windows).await;
     enrich_terminal_windows(&mut windows);
     Ok(windows)
 }
@@ -78,12 +79,11 @@ pub(crate) fn parse_i3_tree(json: &str) -> Result<Vec<WindowInfo>> {
     Ok(windows)
 }
 
-pub fn activate_window(window_id: u64) -> Result<()> {
+pub async fn activate_window(window_id: u64) -> Result<()> {
     let selector = format!(r#"[id="0x{window_id:x}"] focus"#);
-    let output = i3_msg_command()
-        .arg(&selector)
-        .output()
-        .with_context(|| format!("failed to run i3-msg {selector}"))?;
+    let mut command = i3_msg_command_async();
+    command.arg(&selector);
+    let output = command_runner::output(command, &format!("run i3-msg {selector}")).await?;
     if !output.status.success() {
         bail!(
             "i3-msg {selector} failed: {}",
@@ -138,18 +138,19 @@ fn collect_i3_windows(
     }
 }
 
-fn hydrate_i3_window_pids(windows: &mut [WindowInfo]) {
+async fn hydrate_i3_window_pids(windows: &mut [WindowInfo]) {
     for window in windows {
         if window.pid.is_none() {
-            window.pid = i3_window_pid(window.window_id);
+            window.pid = i3_window_pid(window.window_id).await;
         }
     }
 }
 
-fn i3_window_pid(window_id: u64) -> Option<u32> {
-    let output = Command::new("xprop")
-        .args(["-id", &window_id.to_string(), "_NET_WM_PID"])
-        .output()
+async fn i3_window_pid(window_id: u64) -> Option<u32> {
+    let mut command = TokioCommand::new("xprop");
+    command.args(["-id", &window_id.to_string(), "_NET_WM_PID"]);
+    let output = command_runner::output(command, "query X11 window pid")
+        .await
         .ok()?;
     if !output.status.success() {
         return None;
@@ -163,6 +164,14 @@ pub(crate) fn parse_xprop_pid(output: &str) -> Option<u32> {
 
 fn i3_msg_command() -> Command {
     let mut command = Command::new("i3-msg");
+    if let Some(socket_path) = i3_socket_path() {
+        command.arg("-s").arg(socket_path);
+    }
+    command
+}
+
+fn i3_msg_command_async() -> TokioCommand {
+    let mut command = TokioCommand::new("i3-msg");
     if let Some(socket_path) = i3_socket_path() {
         command.arg("-s").arg(socket_path);
     }

--- a/src/windowing/backends/kwin.rs
+++ b/src/windowing/backends/kwin.rs
@@ -74,7 +74,7 @@ struct KwinScriptResult {
 
 async fn call_kwin_activate_script(uuid: &str) -> Result<()> {
     let uuid = uuid.to_string();
-    let json = call_kwin_script(|service_name, callback_object_path, plugin_name| {
+    let json = call_kwin_script(move |service_name, callback_object_path, plugin_name| {
         write_kwin_activate_script(service_name, callback_object_path, plugin_name, &uuid)
     })
     .await?;
@@ -111,17 +111,20 @@ where
     let plugin_name = temporary_kwin_plugin_name();
     let callback_object_path = format!("{KWIN_CALLBACK_OBJECT_PATH_PREFIX}/{plugin_name}");
     let (sender, receiver) = mpsc::channel();
+    let mut cleanup = KwinScriptCleanup::new(
+        connection.clone(),
+        plugin_name.clone(),
+        callback_object_path.clone(),
+    );
     connection
         .object_server()
         .at(callback_object_path.as_str(), KwinWindowCallback { sender })
         .await
         .context("failed to register temporary KWin callback object")?;
 
-    let mut script_path = None;
-    let mut loaded_script = false;
     let result = async {
         let path = write_script(&unique_name, &callback_object_path, &plugin_name)?;
-        script_path = Some(path.clone());
+        cleanup.script_path = Some(path.clone());
         let scripting_proxy = Proxy::new(
             &connection,
             KWIN_SCRIPTING_SERVICE,
@@ -140,7 +143,6 @@ where
             )
             .await
             .context("KWin loadScript failed")?;
-        loaded_script = true;
 
         let _: () = scripting_proxy
             .call("start", &())
@@ -162,8 +164,73 @@ where
         .context("KWin temporary script did not return data before timeout")?
     }
     .await;
+    cleanup.run().await;
+    result
+}
 
-    if loaded_script {
+struct KwinScriptCleanup {
+    connection: zbus::Connection,
+    plugin_name: String,
+    callback_object_path: String,
+    script_path: Option<std::path::PathBuf>,
+    armed: bool,
+}
+
+impl KwinScriptCleanup {
+    fn new(
+        connection: zbus::Connection,
+        plugin_name: String,
+        callback_object_path: String,
+    ) -> Self {
+        Self {
+            connection,
+            plugin_name,
+            callback_object_path,
+            script_path: None,
+            armed: true,
+        }
+    }
+
+    async fn run(&mut self) {
+        cleanup_kwin_script(
+            self.connection.clone(),
+            self.plugin_name.clone(),
+            self.callback_object_path.clone(),
+            self.script_path.clone(),
+        )
+        .await;
+        self.script_path = None;
+        self.armed = false;
+    }
+}
+
+impl Drop for KwinScriptCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let connection = self.connection.clone();
+        let plugin_name = self.plugin_name.clone();
+        let callback_object_path = self.callback_object_path.clone();
+        let script_path = self.script_path.take();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(cleanup_kwin_script(
+                connection,
+                plugin_name,
+                callback_object_path,
+                script_path,
+            ));
+        }
+    }
+}
+
+async fn cleanup_kwin_script(
+    connection: zbus::Connection,
+    plugin_name: String,
+    callback_object_path: String,
+    script_path: Option<std::path::PathBuf>,
+) {
+    let _ = timeout(Duration::from_secs(1), async {
         if let Ok(scripting_proxy) = Proxy::new(
             &connection,
             KWIN_SCRIPTING_SERVICE,
@@ -176,7 +243,8 @@ where
                 .call("unloadScript", &(plugin_name.as_str()))
                 .await;
         }
-    }
+    })
+    .await;
     let _: Result<bool, _> = connection
         .object_server()
         .remove::<KwinWindowCallback, _>(callback_object_path.as_str())
@@ -184,8 +252,6 @@ where
     if let Some(script_path) = script_path {
         let _ = fs::remove_file(script_path);
     }
-
-    result
 }
 
 struct KwinWindowCallback {
@@ -225,7 +291,7 @@ fn write_kwin_window_script(
     write_kwin_script_file(plugin_name, &script)
 }
 
-fn kwin_window_script_source(
+pub(crate) fn kwin_window_script_source(
     service_name: &str,
     callback_object_path: &str,
     plugin_name: &str,
@@ -311,11 +377,30 @@ fn kwin_window_script_source(
         return null;
     }}
 
+    function listWindows() {{
+        try {{
+            if (typeof workspace.windowList === "function") {{
+                return workspace.windowList();
+            }}
+        }} catch (error) {{}}
+        try {{
+            if (typeof workspace.clientList === "function") {{
+                return workspace.clientList();
+            }}
+        }} catch (error) {{}}
+        try {{
+            if (workspace.stackingOrder && typeof workspace.stackingOrder.length === "number") {{
+                return workspace.stackingOrder;
+            }}
+        }} catch (error) {{}}
+        return [];
+    }}
+
     var activeWindow = null;
     try {{
-        activeWindow = workspace.activeWindow;
+        activeWindow = "activeWindow" in workspace ? workspace.activeWindow : workspace.activeClient;
     }} catch (error) {{}}
-    var windows = workspace.windowList().map(function(window) {{
+    var windows = listWindows().map(function(window) {{
         var geo = geometry(window);
         return {{
             uuid: read(window, "uuid"),
@@ -442,6 +527,11 @@ pub(crate) fn kwin_activate_script_source(
             }}
         }} catch (error) {{}}
         try {{
+            if (typeof workspace.clientList === "function") {{
+                return workspace.clientList();
+            }}
+        }} catch (error) {{}}
+        try {{
             if (workspace.stackingOrder && typeof workspace.stackingOrder.length === "number") {{
                 return workspace.stackingOrder;
             }}
@@ -482,13 +572,14 @@ pub(crate) fn kwin_activate_script_source(
 
         var activated = false;
         var activationError = null;
-        try {{
-            workspace.activeWindow = targetWindow;
-            activated = true;
-        }} catch (error) {{
-            activationError = error;
-        }}
-        if (!activated) {{
+        if ("activeWindow" in workspace) {{
+            try {{
+                workspace.activeWindow = targetWindow;
+                activated = true;
+            }} catch (error) {{
+                activationError = error;
+            }}
+        }} else {{
             try {{
                 workspace.activeClient = targetWindow;
                 activated = true;

--- a/src/windowing/backends/x11.rs
+++ b/src/windowing/backends/x11.rs
@@ -10,14 +10,21 @@
 //! [EWMH]: https://specifications.freedesktop.org/wm-spec/latest/
 //! [ICCCM]: https://tronche.com/gui/x/icccm/
 
+use crate::command_runner;
 use crate::terminal::enrich_terminal_windows;
 use crate::windowing::registry::BackendProbe;
 use crate::windowing::types::{WindowBounds, WindowInfo};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use std::env;
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
+use tokio::process::Command as TokioCommand;
+use tokio::time::{sleep, Duration};
 
 pub const X11_BACKEND: &str = "x11";
+const GEOMETRY_VERIFY_ATTEMPTS: usize = 11;
+const GEOMETRY_VERIFY_DELAY: Duration = Duration::from_millis(50);
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// True when this looks like a plain X11 session we can drive over EWMH.
 ///
@@ -35,17 +42,27 @@ fn is_x11_session() -> bool {
     }
 }
 
+pub(crate) fn can_exact_focus() -> bool {
+    is_x11_session() && command_on_path("wmctrl") && command_on_path("xprop")
+}
+
 pub fn probe() -> BackendProbe {
     if !is_x11_session() {
         return probe_fail("no X11 session (needs DISPLAY on an X11, not Wayland, session)");
     }
-    match wmctrl().args(["-l", "-p", "-G", "-x"]).output() {
+    let mut command = wmctrl();
+    command.args(["-l", "-p", "-G", "-x"]);
+    match command_runner::output_blocking_with_timeout(
+        &mut command,
+        "probe X11 windows",
+        PROBE_TIMEOUT,
+    ) {
         Ok(output) if output.status.success() => {
             // Listing only needs wmctrl, but the `focused` flag (and therefore
             // focused_window() and activate_window's focus verification) comes
             // from `_NET_ACTIVE_WINDOW` read via xprop. Without xprop we can list
             // but cannot verify focus, so don't advertise focus capabilities.
-            let can_focus = command_on_path("xprop");
+            let can_focus = can_exact_focus() && active_window_query().is_some();
             BackendProbe {
                 id: X11_BACKEND,
                 ok: true,
@@ -78,17 +95,24 @@ fn probe_fail(detail: &str) -> BackendProbe {
     }
 }
 
-pub fn list_windows() -> Result<Vec<WindowInfo>> {
+pub async fn list_windows() -> Result<Vec<WindowInfo>> {
+    list_windows_with_focus_query(false).await
+}
+
+pub(crate) async fn list_windows_for_exact_focus() -> Result<Vec<WindowInfo>> {
+    list_windows_with_focus_query(true).await
+}
+
+async fn list_windows_with_focus_query(require_focus_query: bool) -> Result<Vec<WindowInfo>> {
     // Guard the session too, not just probe(): registry::list_windows() tries
     // each backend directly, so without this a Wayland session with no native
     // backend would fall through here and return XWayland-only windows.
     if !is_x11_session() {
         bail!("not an X11 session (needs DISPLAY on an X11, not Wayland, session)");
     }
-    let output = wmctrl()
-        .args(["-l", "-p", "-G", "-x"])
-        .output()
-        .context("failed to run wmctrl -l -p -G -x")?;
+    let mut command = wmctrl_async();
+    command.args(["-l", "-p", "-G", "-x"]);
+    let output = command_runner::output(command, "run wmctrl -l -p -G -x").await?;
     if !output.status.success() {
         bail!(
             "wmctrl -l -p -G -x failed: {}",
@@ -96,19 +120,20 @@ pub fn list_windows() -> Result<Vec<WindowInfo>> {
         );
     }
 
-    let active_id = active_window_id();
+    let active_id =
+        resolve_active_window_query(active_window_query_async().await, require_focus_query)?;
     let mut windows = parse_wmctrl_windows(&String::from_utf8_lossy(&output.stdout), active_id);
     enrich_terminal_windows(&mut windows);
     Ok(windows)
 }
 
-pub fn activate_window(window_id: u64) -> Result<()> {
+pub async fn activate_window(window_id: u64) -> Result<()> {
     let id = window_id_arg(window_id);
-    run_wmctrl(&["-i", "-a", id.as_str()], "activate window", window_id)
+    run_wmctrl(&["-i", "-a", id.as_str()], "activate window", window_id).await
 }
 
-pub fn move_window(window_id: u64, x: i32, y: i32) -> Result<String> {
-    unmaximize(window_id)?;
+pub async fn move_window(window_id: u64, x: i32, y: i32) -> Result<String> {
+    unmaximize(window_id).await?;
     let id = window_id_arg(window_id);
     // wmctrl -e is `gravity,x,y,width,height`; the trailing -1,-1 keep the size.
     // wmctrl also reads -1 in the x/y fields as "preserve current position", so a
@@ -118,8 +143,23 @@ pub fn move_window(window_id: u64, x: i32, y: i32) -> Result<String> {
         &["-i", "-r", id.as_str(), "-e", geometry.as_str()],
         "move window",
         window_id,
-    )?;
-    Ok(format!("Moved window to ({x}, {y}) via X11/EWMH (wmctrl)."))
+    )
+    .await?;
+    let expected_x = wmctrl_move_coord(x);
+    let expected_y = wmctrl_move_coord(y);
+    let (bounds, exact) = wait_for_window_geometry(window_id, |bounds| {
+        bounds_at_position(bounds, expected_x, expected_y)
+    })
+    .await?;
+    if exact {
+        Ok(format!("Moved window to ({x}, {y}) via X11/EWMH (wmctrl)."))
+    } else {
+        Ok(format!(
+            "Requested move to ({x}, {y}) via X11/EWMH; the window manager reported position ({}, {}).",
+            bounds.x.map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+            bounds.y.map_or_else(|| "unknown".to_string(), |value| value.to_string())
+        ))
+    }
 }
 
 /// `wmctrl -e` treats -1 in any field as "keep current value", so a literal -1
@@ -133,29 +173,88 @@ fn wmctrl_move_coord(value: i32) -> i32 {
     }
 }
 
-pub fn resize_window(window_id: u64, width: i32, height: i32) -> Result<String> {
+pub async fn resize_window(window_id: u64, width: i32, height: i32) -> Result<String> {
     // wmctrl -e reads -1 (and rejects <= 0) as "preserve current value" per
     // field, so a non-positive size would silently leave a dimension unchanged
     // while reporting success. Reject it up front.
     if width <= 0 || height <= 0 {
         bail!("resize requires positive width and height (got {width}x{height})");
     }
-    unmaximize(window_id)?;
+    unmaximize(window_id).await?;
     let id = window_id_arg(window_id);
     let geometry = format!("0,-1,-1,{width},{height}");
     run_wmctrl(
         &["-i", "-r", id.as_str(), "-e", geometry.as_str()],
         "resize window",
         window_id,
-    )?;
-    Ok(format!(
-        "Resized window to {width}x{height} via X11/EWMH (wmctrl)."
-    ))
+    )
+    .await?;
+    let (bounds, exact) = wait_for_window_geometry(window_id, |bounds| {
+        bounds_at_size(bounds, width as u32, height as u32)
+    })
+    .await?;
+    if exact {
+        Ok(format!(
+            "Resized window to {width}x{height} via X11/EWMH (wmctrl)."
+        ))
+    } else {
+        Ok(format!(
+            "Requested resize to {width}x{height} via X11/EWMH; the window manager reported {}x{}.",
+            bounds.width, bounds.height
+        ))
+    }
+}
+
+async fn wait_for_window_geometry(
+    window_id: u64,
+    matches: impl Fn(&WindowBounds) -> bool,
+) -> Result<(WindowBounds, bool)> {
+    let mut last_bounds = None;
+    for attempt in 0..GEOMETRY_VERIFY_ATTEMPTS {
+        if let Some(bounds) = query_window_bounds(window_id).await {
+            if matches(&bounds) {
+                return Ok((bounds, true));
+            }
+            last_bounds = Some(bounds);
+        }
+        if attempt + 1 < GEOMETRY_VERIFY_ATTEMPTS {
+            sleep(GEOMETRY_VERIFY_DELAY).await;
+        }
+    }
+    match last_bounds {
+        Some(bounds) => Ok((bounds, false)),
+        None => {
+            bail!("X11/EWMH window 0x{window_id:x} could not be queried after the geometry request")
+        }
+    }
+}
+
+async fn query_window_bounds(window_id: u64) -> Option<WindowBounds> {
+    let mut command = wmctrl_async();
+    command.args(["-l", "-p", "-G", "-x"]);
+    let output = command_runner::output(command, "query X11 window geometry")
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_wmctrl_windows(&String::from_utf8_lossy(&output.stdout), None)
+        .into_iter()
+        .find(|window| window.window_id == window_id)
+        .and_then(|window| window.bounds)
+}
+
+fn bounds_at_position(bounds: &WindowBounds, x: i32, y: i32) -> bool {
+    bounds.x == Some(x) && bounds.y == Some(y)
+}
+
+fn bounds_at_size(bounds: &WindowBounds, width: u32, height: u32) -> bool {
+    bounds.width == width && bounds.height == height
 }
 
 /// EWMH move/resize only take effect on unmaximized windows, so drop the
 /// maximized state first (mirrors the GNOME extension backend behaviour).
-fn unmaximize(window_id: u64) -> Result<()> {
+async fn unmaximize(window_id: u64) -> Result<()> {
     let id = window_id_arg(window_id);
     run_wmctrl(
         &[
@@ -168,13 +267,14 @@ fn unmaximize(window_id: u64) -> Result<()> {
         "unmaximize window",
         window_id,
     )
+    .await
 }
 
-fn run_wmctrl(args: &[&str], action: &str, window_id: u64) -> Result<()> {
-    let output = wmctrl()
-        .args(args)
-        .output()
-        .with_context(|| format!("failed to run wmctrl to {action} 0x{window_id:x}"))?;
+async fn run_wmctrl(args: &[&str], action: &str, window_id: u64) -> Result<()> {
+    let mut command = wmctrl_async();
+    command.args(args);
+    let output =
+        command_runner::output(command, &format!("run wmctrl to {action} 0x{window_id:x}")).await?;
     if !output.status.success() {
         bail!(
             "wmctrl failed to {action} 0x{window_id:x}: {}",
@@ -192,27 +292,55 @@ fn wmctrl() -> Command {
     Command::new("wmctrl")
 }
 
-fn active_window_id() -> Option<u64> {
-    let output = Command::new("xprop")
-        .args(["-root", "-notype", "_NET_ACTIVE_WINDOW"])
-        .output()
+fn wmctrl_async() -> TokioCommand {
+    TokioCommand::new("wmctrl")
+}
+
+async fn active_window_query_async() -> Option<Option<u64>> {
+    let mut command = TokioCommand::new("xprop");
+    command.args(["-root", "-notype", "_NET_ACTIVE_WINDOW"]);
+    let output = command_runner::output(command, "query the active X11 window")
+        .await
         .ok()?;
     if !output.status.success() {
         return None;
     }
-    parse_active_window_id(&String::from_utf8_lossy(&output.stdout))
+    parse_active_window_query(&String::from_utf8_lossy(&output.stdout))
 }
 
-/// Parse the window id out of an `xprop _NET_ACTIVE_WINDOW` line, e.g.
-/// `_NET_ACTIVE_WINDOW: window id # 0x7000004`. Returns `None` for `0x0`.
-pub(crate) fn parse_active_window_id(xprop_output: &str) -> Option<u64> {
+fn resolve_active_window_query(
+    query: Option<Option<u64>>,
+    require_focus_query: bool,
+) -> Result<Option<u64>> {
+    if require_focus_query && query.is_none() {
+        bail!("xprop could not query _NET_ACTIVE_WINDOW");
+    }
+    Ok(query.flatten())
+}
+
+fn active_window_query() -> Option<Option<u64>> {
+    let mut command = Command::new("xprop");
+    command.args(["-root", "-notype", "_NET_ACTIVE_WINDOW"]);
+    let output = command_runner::output_blocking_with_timeout(
+        &mut command,
+        "probe the active X11 window",
+        PROBE_TIMEOUT,
+    )
+    .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_active_window_query(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_active_window_query(xprop_output: &str) -> Option<Option<u64>> {
     let after = xprop_output.split("0x").nth(1)?;
     let hex: String = after
         .chars()
         .take_while(|character| character.is_ascii_hexdigit())
         .collect();
     let id = u64::from_str_radix(&hex, 16).ok()?;
-    (id != 0).then_some(id)
+    Some((id != 0).then_some(id))
 }
 
 /// Parse `wmctrl -l -p -G -x` output into window records.
@@ -309,8 +437,13 @@ fn env_nonempty(name: &str) -> Option<String> {
 /// capabilities on `xprop` without spawning it (xprop with no args would block
 /// reading a window interactively).
 fn command_on_path(cmd: &str) -> bool {
-    env::var_os("PATH")
-        .is_some_and(|paths| env::split_paths(&paths).any(|dir| dir.join(cmd).is_file()))
+    env::var_os("PATH").is_some_and(|paths| {
+        env::split_paths(&paths).any(|dir| {
+            dir.join(cmd).metadata().is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+        })
+    })
 }
 
 #[cfg(test)]
@@ -320,17 +453,32 @@ mod tests {
     #[test]
     fn parses_active_window_id_from_xprop() {
         assert_eq!(
-            parse_active_window_id("_NET_ACTIVE_WINDOW: window id # 0x7000004\n"),
-            Some(0x7000004)
+            parse_active_window_query("_NET_ACTIVE_WINDOW: window id # 0x7000004\n"),
+            Some(Some(0x7000004))
         );
         assert_eq!(
-            parse_active_window_id("_NET_ACTIVE_WINDOW(WINDOW): window id # 0x03a00017\n"),
-            Some(0x03a00017)
+            parse_active_window_query("_NET_ACTIVE_WINDOW(WINDOW): window id # 0x03a00017\n"),
+            Some(Some(0x03a00017))
         );
         assert_eq!(
-            parse_active_window_id("_NET_ACTIVE_WINDOW: window id # 0x0\n"),
+            parse_active_window_query("_NET_ACTIVE_WINDOW: window id # 0x0\n"),
+            Some(None)
+        );
+        assert_eq!(
+            parse_active_window_query("_NET_ACTIVE_WINDOW:  not found.\n"),
             None
         );
+    }
+
+    #[test]
+    fn exact_focus_listing_requires_a_live_active_window_query() {
+        assert!(resolve_active_window_query(None, true).is_err());
+        assert_eq!(resolve_active_window_query(Some(None), true).unwrap(), None);
+        assert_eq!(
+            resolve_active_window_query(Some(Some(0x7000004)), true).unwrap(),
+            Some(0x7000004)
+        );
+        assert_eq!(resolve_active_window_query(None, false).unwrap(), None);
     }
 
     #[test]
@@ -383,6 +531,20 @@ mod tests {
         assert_eq!(wmctrl_move_coord(0), 0);
         assert_eq!(wmctrl_move_coord(-40), -40);
         assert_eq!(wmctrl_move_coord(1920), 1920);
+    }
+
+    #[test]
+    fn geometry_matchers_require_the_requested_values() {
+        let bounds = WindowBounds {
+            x: Some(10),
+            y: Some(20),
+            width: 800,
+            height: 600,
+        };
+        assert!(bounds_at_position(&bounds, 10, 20));
+        assert!(!bounds_at_position(&bounds, 11, 20));
+        assert!(bounds_at_size(&bounds, 800, 600));
+        assert!(!bounds_at_size(&bounds, 801, 600));
     }
 
     #[test]

--- a/src/windowing/mod.rs
+++ b/src/windowing/mod.rs
@@ -22,7 +22,8 @@ mod tests {
     use super::backends::hyprland::{parse_hyprland_clients, HYPRLAND_BACKEND};
     use super::backends::i3::{parse_i3_tree, parse_xprop_pid, I3_BACKEND};
     use super::backends::kwin::{
-        kwin_activate_script_source, kwin_window_id_from_uuid, parse_kwin_windows, KWIN_BACKEND,
+        kwin_activate_script_source, kwin_window_id_from_uuid, kwin_window_script_source,
+        parse_kwin_windows, KWIN_BACKEND,
     };
     use super::registry::{
         descriptors, list_note, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND,
@@ -700,6 +701,24 @@ mod tests {
     }
 
     #[test]
+    fn kwin_window_script_supports_plasma5_and_plasma6_window_apis() {
+        let script = kwin_window_script_source(
+            ":1.234",
+            "/dev/avifenesh/ComputerUseLinux/KWinWindowQuery/test",
+            "computer_use_linux_kwin_window_query_test",
+        )
+        .unwrap();
+
+        assert!(script.contains(r#"typeof workspace.windowList === "function""#));
+        assert!(script.contains("workspace.windowList()"));
+        assert!(script.contains(r#"typeof workspace.clientList === "function""#));
+        assert!(script.contains("workspace.clientList()"));
+        assert!(script.contains(
+            r#"activeWindow = "activeWindow" in workspace ? workspace.activeWindow : workspace.activeClient;"#
+        ));
+    }
+
+    #[test]
     fn kwin_activation_script_focuses_window_directly() {
         let script = kwin_activate_script_source(
             ":1.234",
@@ -712,6 +731,10 @@ mod tests {
         assert!(script.contains(r#"var targetUuid = "b4dfacf8-a559-43c9-8b1f-ecd5cfd78359";"#));
         assert!(script.contains("targetWindow.minimized = false;"));
         assert!(script.contains("workspace.activeWindow = targetWindow;"));
+        assert!(script.contains(r#"typeof workspace.clientList === "function""#));
+        assert!(script.contains("workspace.clientList()"));
+        assert!(script.contains(r#""activeWindow" in workspace"#));
+        assert!(script.contains("workspace.activeClient = targetWindow;"));
         assert!(script.contains(r#""ReceiveResult""#));
         assert!(!script.contains("WindowsRunner"));
     }

--- a/src/windowing/registry.rs
+++ b/src/windowing/registry.rs
@@ -99,7 +99,7 @@ const DESCRIPTORS: &[BackendDescriptor] = &[
         id: X11_BACKEND,
         failure_label: "X11/EWMH",
         list_note: "Window list came from X11/EWMH (wmctrl). Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
-        missing_hint: "On other X11 window managers (Cinnamon, MATE, Xfce, Openbox…), ensure wmctrl and xprop are installed.",
+        missing_hint: "On other X11 window managers (Cinnamon, MATE, Xfce, Openbox, etc.), ensure wmctrl and xprop are installed.",
         can_exact_focus: true,
     },
 ];
@@ -123,7 +123,11 @@ pub fn list_note(id: &str) -> &'static str {
 }
 
 pub fn backend_can_exact_focus(id: &str) -> bool {
-    descriptor(id).is_some_and(|descriptor| descriptor.can_exact_focus)
+    if id == X11_BACKEND {
+        x11::can_exact_focus()
+    } else {
+        descriptor(id).is_some_and(|descriptor| descriptor.can_exact_focus)
+    }
 }
 
 pub async fn list_windows() -> Result<Vec<WindowInfo>> {
@@ -132,10 +136,28 @@ pub async fn list_windows() -> Result<Vec<WindowInfo>> {
         if let Some(windows) =
             usable_backend_windows(*backend, list_windows_for(*backend).await, &mut errors)
         {
+            if matches!(backend, BackendKind::GnomeIntrospect) {
+                let x11_result = if x11::can_exact_focus() {
+                    Some(x11::list_windows_for_exact_focus().await)
+                } else {
+                    None
+                };
+                return Ok(prefer_exact_x11_windows(windows, x11_result, &mut errors));
+            }
             return Ok(windows);
         }
     }
     Err(anyhow!(errors.join("; ")))
+}
+
+fn prefer_exact_x11_windows(
+    introspect_windows: Vec<WindowInfo>,
+    x11_result: Option<Result<Vec<WindowInfo>>>,
+    errors: &mut Vec<String>,
+) -> Vec<WindowInfo> {
+    x11_result
+        .and_then(|result| usable_backend_windows(BackendKind::X11, result, errors))
+        .unwrap_or(introspect_windows)
 }
 
 fn usable_backend_windows(
@@ -160,11 +182,11 @@ async fn list_windows_for(backend: BackendKind) -> Result<Vec<WindowInfo>> {
     match backend {
         BackendKind::GnomeExtension => gnome::list_extension_windows().await,
         BackendKind::GnomeIntrospect => gnome::list_introspect_windows().await,
-        BackendKind::Cosmic => cosmic::list_windows(),
+        BackendKind::Cosmic => cosmic::list_windows().await,
         BackendKind::Kwin => kwin::list_windows().await,
-        BackendKind::Hyprland => hyprland::list_windows(),
-        BackendKind::I3 => i3::list_windows(),
-        BackendKind::X11 => x11::list_windows(),
+        BackendKind::Hyprland => hyprland::list_windows().await,
+        BackendKind::I3 => i3::list_windows().await,
+        BackendKind::X11 => x11::list_windows().await,
     }
 }
 
@@ -184,15 +206,33 @@ pub async fn activate_window(window: &WindowInfo) -> Result<()> {
                 })?;
             gnome::focus_app(app_id).await
         }
-        COSMIC_WAYLAND_BACKEND => cosmic::activate_window(window.window_id),
+        COSMIC_WAYLAND_BACKEND => cosmic::activate_window(window.window_id).await,
         KWIN_BACKEND => kwin::activate_window(window.window_id).await,
-        HYPRLAND_BACKEND => hyprland::activate_window(window.window_id),
-        I3_BACKEND => i3::activate_window(window.window_id),
-        X11_BACKEND => x11::activate_window(window.window_id),
+        HYPRLAND_BACKEND => hyprland::activate_window(window.window_id).await,
+        I3_BACKEND => i3::activate_window(window.window_id).await,
+        X11_BACKEND => x11::activate_window(window.window_id).await,
         backend => Err(anyhow!(
             "Unsupported window backend for activation: {backend}"
         )),
     }
+}
+
+pub async fn focused_window_for_backend(backend: &str) -> Result<Option<WindowInfo>> {
+    let windows = match backend {
+        GNOME_SHELL_EXTENSION_BACKEND => gnome::list_extension_windows().await?,
+        GNOME_SHELL_INTROSPECT_BACKEND => gnome::list_introspect_windows().await?,
+        COSMIC_WAYLAND_BACKEND => return cosmic::focused_window().await,
+        KWIN_BACKEND => kwin::list_windows().await?,
+        HYPRLAND_BACKEND => hyprland::list_windows().await?,
+        I3_BACKEND => i3::list_windows().await?,
+        X11_BACKEND => x11::list_windows_for_exact_focus().await?,
+        backend => {
+            return Err(anyhow!(
+                "Unsupported window backend for focus query: {backend}"
+            ))
+        }
+    };
+    Ok(windows.into_iter().find(|window| window.focused))
 }
 
 pub async fn move_window(window: &WindowInfo, x: i32, y: i32) -> Result<String> {
@@ -200,7 +240,7 @@ pub async fn move_window(window: &WindowInfo, x: i32, y: i32) -> Result<String> 
         GNOME_SHELL_EXTENSION_BACKEND => {
             gnome::move_extension_window(window.window_id, x, y).await
         }
-        X11_BACKEND => x11::move_window(window.window_id, x, y),
+        X11_BACKEND => x11::move_window(window.window_id, x, y).await,
         backend => Err(anyhow!(
             "Window backend {backend} cannot move windows; move_window needs the computer-use-linux GNOME Shell extension or a generic X11/EWMH session."
         )),
@@ -212,15 +252,15 @@ pub async fn resize_window(window: &WindowInfo, width: i32, height: i32) -> Resu
         GNOME_SHELL_EXTENSION_BACKEND => {
             gnome::resize_extension_window(window.window_id, width, height).await
         }
-        X11_BACKEND => x11::resize_window(window.window_id, width, height),
+        X11_BACKEND => x11::resize_window(window.window_id, width, height).await,
         backend => Err(anyhow!(
             "Window backend {backend} cannot resize windows; resize_window needs the computer-use-linux GNOME Shell extension or a generic X11/EWMH session."
         )),
     }
 }
 
-pub fn focused_window_override() -> Option<WindowInfo> {
-    cosmic::focused_window().ok().flatten()
+pub async fn focused_window_override() -> Option<WindowInfo> {
+    cosmic::focused_window().await.ok().flatten()
 }
 
 pub fn probe_backends() -> Vec<BackendProbe> {
@@ -300,6 +340,31 @@ mod tests {
 
         assert_eq!(windows[0].backend, KWIN_BACKEND);
         assert_eq!(errors, vec!["GNOME Shell Introspect returned no windows"]);
+    }
+
+    #[test]
+    fn exact_x11_result_wins_over_gnome_list_only_result() {
+        let mut errors = Vec::new();
+        let selected = prefer_exact_x11_windows(
+            vec![window(GNOME_SHELL_INTROSPECT_BACKEND)],
+            Some(Ok(vec![window(X11_BACKEND)])),
+            &mut errors,
+        );
+        assert_eq!(selected[0].backend, X11_BACKEND);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn gnome_list_only_result_survives_failed_x11_listing() {
+        let mut errors = Vec::new();
+        let selected = prefer_exact_x11_windows(
+            vec![window(GNOME_SHELL_INTROSPECT_BACKEND)],
+            Some(Err(anyhow!("wmctrl failed"))),
+            &mut errors,
+        );
+
+        assert_eq!(selected[0].backend, GNOME_SHELL_INTROSPECT_BACKEND);
+        assert_eq!(errors, ["X11/EWMH failed: wmctrl failed"]);
     }
 
     #[test]

--- a/src/windowing/target.rs
+++ b/src/windowing/target.rs
@@ -1,9 +1,10 @@
 use crate::windowing::registry::{self, WINDOW_PERMISSION_HINT};
 use crate::windowing::types::{WindowFocusResult, WindowInfo, WindowTarget};
 use anyhow::{bail, Result};
-use tokio::time::{sleep, Duration};
+use std::future::Future;
+use tokio::time::{sleep_until, timeout_at, Duration, Instant};
 
-const FOCUS_VERIFY_ATTEMPTS: usize = 21;
+const FOCUS_VERIFY_TIMEOUT: Duration = Duration::from_secs(1);
 const FOCUS_VERIFY_DELAY: Duration = Duration::from_millis(50);
 
 pub async fn list_windows() -> Result<Vec<WindowInfo>> {
@@ -58,7 +59,7 @@ pub(crate) fn ensure_backend_can_focus_target(
 }
 
 async fn current_focused_window() -> Result<Option<WindowInfo>> {
-    if let Some(window) = registry::focused_window_override() {
+    if let Some(window) = registry::focused_window_override().await {
         return Ok(Some(window));
     }
 
@@ -69,23 +70,45 @@ async fn current_focused_window() -> Result<Option<WindowInfo>> {
 }
 
 async fn wait_for_focused_window(requested_window: &WindowInfo) -> Option<WindowInfo> {
+    wait_for_focused_window_with(requested_window, FOCUS_VERIFY_TIMEOUT, || {
+        registry::focused_window_for_backend(&requested_window.backend)
+    })
+    .await
+}
+
+async fn wait_for_focused_window_with<F, Fut>(
+    requested_window: &WindowInfo,
+    verify_timeout: Duration,
+    mut query: F,
+) -> Option<WindowInfo>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<WindowInfo>>>,
+{
+    let deadline = Instant::now() + verify_timeout;
     let mut last_focused_window = None;
-    for attempt in 0..FOCUS_VERIFY_ATTEMPTS {
-        if let Ok(focused_window) = current_focused_window().await {
-            if focused_window
-                .as_ref()
-                .is_some_and(|window| window.window_id == requested_window.window_id)
-            {
-                return focused_window;
+    loop {
+        match timeout_at(deadline, query()).await {
+            Ok(Ok(focused_window)) => {
+                if focused_window
+                    .as_ref()
+                    .is_some_and(|window| window.window_id == requested_window.window_id)
+                {
+                    return focused_window;
+                }
+                if focused_window.is_some() {
+                    last_focused_window = focused_window;
+                }
             }
-            if focused_window.is_some() {
-                last_focused_window = focused_window;
-            }
+            Ok(Err(_)) => {}
+            Err(_) => break,
         }
 
-        if attempt + 1 < FOCUS_VERIFY_ATTEMPTS {
-            sleep(FOCUS_VERIFY_DELAY).await;
+        let now = Instant::now();
+        if now >= deadline {
+            break;
         }
+        sleep_until((now + FOCUS_VERIFY_DELAY).min(deadline)).await;
     }
     last_focused_window
 }
@@ -378,7 +401,35 @@ mod tests {
 
     #[test]
     fn focus_verification_allows_workspace_transition_latency() {
-        let verification_budget = FOCUS_VERIFY_DELAY * (FOCUS_VERIFY_ATTEMPTS - 1) as u32;
-        assert!(verification_budget >= Duration::from_secs(1));
+        assert!(FOCUS_VERIFY_TIMEOUT >= Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn slow_focus_query_cannot_exceed_verification_deadline() {
+        let requested_window = WindowInfo {
+            window_id: 1,
+            title: None,
+            app_id: None,
+            wm_class: None,
+            pid: None,
+            bounds: None,
+            workspace: None,
+            focused: false,
+            hidden: false,
+            client_type: None,
+            backend: "test".to_string(),
+            terminal: None,
+        };
+        let started = Instant::now();
+
+        let focused =
+            wait_for_focused_window_with(&requested_window, Duration::from_millis(20), || async {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                Ok::<_, anyhow::Error>(None)
+            })
+            .await;
+
+        assert!(focused.is_none());
+        assert!(started.elapsed() < Duration::from_millis(500));
     }
 }

--- a/src/ydotool.rs
+++ b/src/ydotool.rs
@@ -1,0 +1,848 @@
+use crate::command_runner;
+use std::{
+    env,
+    ffi::{CString, OsStr, OsString},
+    fs, io,
+    os::unix::{
+        ffi::{OsStrExt, OsStringExt},
+        fs::{DirBuilderExt, MetadataExt, PermissionsExt},
+        net::UnixDatagram,
+    },
+    path::{Path, PathBuf},
+    process::{self, Command, Stdio},
+    sync::{Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliGeneration {
+    RawEvents,
+    LegacyNamed,
+}
+
+const MAX_UNIX_SOCKET_PATH_BYTES: usize = 107;
+const PROBE_DIRECTORY_ATTEMPTS: usize = 8;
+const PROBE_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+const FAILED_PROBE_CACHE_TTL: Duration = Duration::from_secs(5);
+const PROBE_PREFIX: &str = ".computer-use-linux-ydotool-probe";
+const UNSUPPORTED_MESSAGE: &str = "unsupported ydotool CLI; Computer Use requires ydotool 1.0.3 or newer with raw key events, wheel movement, stdin typing, and absolute mouse movement";
+
+struct ProbeSocket {
+    _socket: UnixDatagram,
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExecutableFingerprint {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+    length: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SupportedYdotool {
+    pub(crate) executable: PathBuf,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ProbeCacheKey {
+    Executable(ExecutableFingerprint),
+    SearchPath {
+        path: OsString,
+        current_dir: Option<PathBuf>,
+    },
+}
+
+struct CachedProbe<K, V> {
+    key: K,
+    result: Result<V, String>,
+    checked_at: Instant,
+}
+
+impl ProbeSocket {
+    fn bind_with(runtime_dir: Option<&OsStr>, temp_dir: &Path) -> Result<Self, String> {
+        let uid = unsafe { libc::geteuid() };
+        let mut failures = Vec::new();
+        for base in probe_socket_bases(runtime_dir, temp_dir) {
+            if let Err(error) = validate_probe_base(&base, uid) {
+                failures.push(format!("{}: {error}", base.display()));
+                continue;
+            }
+            match Self::bind_in(&base) {
+                Ok(socket) => return Ok(socket),
+                Err(error) => failures.push(format!("{}: {error}", base.display())),
+            }
+        }
+
+        let detail = if failures.is_empty() {
+            "no candidate runtime directory was available".to_string()
+        } else {
+            failures.join("; ")
+        };
+        Err(format!(
+            "failed to bind isolated ydotool probe socket: {detail}"
+        ))
+    }
+
+    fn bind_in(base: &Path) -> io::Result<Self> {
+        let sample_path = base.join(format!(
+            "{PROBE_PREFIX}-{}-0000000000000000/s",
+            process::id()
+        ));
+        if !unix_socket_path_fits(&sample_path) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "probe socket path is too long",
+            ));
+        }
+
+        for _ in 0..PROBE_DIRECTORY_ATTEMPTS {
+            let nonce = random_hex(8)?;
+            let directory = base.join(format!("{PROBE_PREFIX}-{}-{nonce}", process::id()));
+            let path = directory.join("s");
+            let mut builder = fs::DirBuilder::new();
+            builder.mode(0o700);
+            match builder.create(&directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+            if let Err(error) = fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)) {
+                let _ = fs::remove_dir(&directory);
+                return Err(error);
+            }
+            match UnixDatagram::bind(&path) {
+                Ok(socket) => {
+                    return Ok(Self {
+                        _socket: socket,
+                        directory,
+                        path,
+                    });
+                }
+                Err(error) => {
+                    let _ = fs::remove_file(&path);
+                    let _ = fs::remove_dir(&directory);
+                    return Err(error);
+                }
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique probe directory",
+        ))
+    }
+}
+
+impl Drop for ProbeSocket {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+        let _ = fs::remove_dir(&self.directory);
+    }
+}
+
+pub(crate) fn ensure_supported() -> Result<SupportedYdotool, String> {
+    static SUPPORTED: OnceLock<Mutex<Option<CachedProbe<ProbeCacheKey, SupportedYdotool>>>> =
+        OnceLock::new();
+    let search_path = executable_search_path();
+    let current_dir = env::current_dir().ok();
+    let executable = resolve_executable_with("ydotool", &search_path, current_dir.as_deref());
+    let key = executable
+        .as_deref()
+        .and_then(executable_fingerprint)
+        .map(ProbeCacheKey::Executable)
+        .unwrap_or_else(|| ProbeCacheKey::SearchPath {
+            path: search_path,
+            current_dir,
+        });
+    cached_result_or_probe(
+        SUPPORTED.get_or_init(|| Mutex::new(None)),
+        key,
+        FAILED_PROBE_CACHE_TTL,
+        move || probe_executable(executable),
+    )
+}
+
+pub(crate) async fn ensure_supported_async() -> Result<SupportedYdotool, String> {
+    tokio::task::spawn_blocking(ensure_supported)
+        .await
+        .map_err(|error| format!("ydotool capability probe task failed: {error}"))?
+}
+
+fn cached_result_or_probe<K: PartialEq, V: Clone>(
+    cache: &Mutex<Option<CachedProbe<K, V>>>,
+    key: K,
+    failure_ttl: Duration,
+    probe: impl FnOnce() -> Result<V, String>,
+) -> Result<V, String> {
+    let Ok(mut cached) = cache.lock() else {
+        return probe();
+    };
+    if let Some(cached) = cached.as_ref() {
+        if cached.key == key && (cached.result.is_ok() || cached.checked_at.elapsed() < failure_ttl)
+        {
+            return cached.result.clone();
+        }
+    }
+    let result = probe();
+    *cached = Some(CachedProbe {
+        key,
+        result: result.clone(),
+        checked_at: Instant::now(),
+    });
+    result
+}
+
+fn executable_search_path() -> OsString {
+    env::var_os("PATH").unwrap_or_else(default_search_path)
+}
+
+fn default_search_path() -> OsString {
+    let length = unsafe { libc::confstr(libc::_CS_PATH, std::ptr::null_mut(), 0) };
+    if length == 0 {
+        return OsString::from("/bin:/usr/bin");
+    }
+    let mut buffer = vec![0_u8; length];
+    let written = unsafe {
+        libc::confstr(
+            libc::_CS_PATH,
+            buffer.as_mut_ptr().cast::<libc::c_char>(),
+            buffer.len(),
+        )
+    };
+    if written == 0 {
+        return OsString::from("/bin:/usr/bin");
+    }
+    if buffer.last() == Some(&0) {
+        buffer.pop();
+    }
+    OsString::from_vec(buffer)
+}
+
+fn resolve_executable_with(
+    command: &str,
+    search_path: &OsStr,
+    current_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    env::split_paths(search_path)
+        .filter_map(|directory| {
+            let directory = if directory.as_os_str().is_empty() {
+                current_dir?.to_path_buf()
+            } else if directory.is_absolute() {
+                directory
+            } else {
+                current_dir?.join(directory)
+            };
+            Some(directory.join(command))
+        })
+        .find(|path| executable_by_effective_user(path))
+}
+
+fn executable_by_effective_user(path: &Path) -> bool {
+    if !path.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return false;
+    }
+    let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+    unsafe { libc::faccessat(libc::AT_FDCWD, path.as_ptr(), libc::X_OK, libc::AT_EACCESS) == 0 }
+}
+
+fn executable_fingerprint(path: &Path) -> Option<ExecutableFingerprint> {
+    let metadata = path.metadata().ok()?;
+    Some(ExecutableFingerprint {
+        path: path.to_path_buf(),
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        length: metadata.len(),
+        modified_seconds: metadata.mtime(),
+        modified_nanoseconds: metadata.mtime_nsec(),
+        changed_seconds: metadata.ctime(),
+        changed_nanoseconds: metadata.ctime_nsec(),
+    })
+}
+
+fn probe_executable(executable: Option<PathBuf>) -> Result<SupportedYdotool, String> {
+    let executable =
+        executable.ok_or_else(|| "ydotool executable was not found in PATH".to_string())?;
+    let runtime_dir = env::var_os("XDG_RUNTIME_DIR");
+    let detail = probe_with(&executable, runtime_dir.as_deref(), &env::temp_dir())?;
+    Ok(SupportedYdotool { executable, detail })
+}
+
+fn probe_with(
+    ydotool_path: &Path,
+    runtime_dir: Option<&OsStr>,
+    temp_dir: &Path,
+) -> Result<String, String> {
+    let mut output_text = String::new();
+    for argument in ["help", "--help"] {
+        let mut command = Command::new(ydotool_path);
+        command.arg(argument);
+        let output = command_output_with_timeout(&mut command, "ydotool", PROBE_COMMAND_TIMEOUT)?;
+        output_text.push_str(&String::from_utf8_lossy(&output.stdout));
+        output_text.push_str(&String::from_utf8_lossy(&output.stderr));
+        if let Some(generation) = classify_help(&output_text) {
+            return match generation {
+                CliGeneration::RawEvents => {
+                    probe_raw_semantics(ydotool_path, runtime_dir, temp_dir)
+                        .map(|()| "compatible raw-event CLI detected".to_string())
+                }
+                CliGeneration::LegacyNamed => Err(UNSUPPORTED_MESSAGE.to_string()),
+            };
+        }
+    }
+    Err("unrecognized ydotool CLI; Computer Use requires ydotool 1.0.3 or newer".to_string())
+}
+
+fn probe_raw_semantics(
+    ydotool_path: &Path,
+    runtime_dir: Option<&OsStr>,
+    temp_dir: &Path,
+) -> Result<(), String> {
+    let absolute = run_probe_command(
+        ydotool_path,
+        runtime_dir,
+        temp_dir,
+        &["mousemove", "--absolute", "--", "0", "0"],
+        None,
+    )?;
+    require_semantic_probe(&absolute)?;
+    let wheel = run_probe_command(
+        ydotool_path,
+        runtime_dir,
+        temp_dir,
+        &["mousemove", "--wheel", "--", "0", "0"],
+        None,
+    )?;
+    require_semantic_probe(&wheel)?;
+    let click = run_probe_command(
+        ydotool_path,
+        runtime_dir,
+        temp_dir,
+        &["click", "0xC0"],
+        None,
+    )?;
+    require_semantic_probe(&click)?;
+    let key = run_probe_command(
+        ydotool_path,
+        runtime_dir,
+        temp_dir,
+        &["key", "-d", "100", "1:1", "1:0"],
+        None,
+    )?;
+    require_semantic_probe(&key)?;
+    let type_from_stdin = run_probe_command(
+        ydotool_path,
+        runtime_dir,
+        temp_dir,
+        &["type", "--file", "-"],
+        Some(Path::new("/proc/self/fd")),
+    )?;
+    require_semantic_probe(&type_from_stdin)
+}
+
+fn run_probe_command(
+    ydotool_path: &Path,
+    runtime_dir: Option<&OsStr>,
+    temp_dir: &Path,
+    args: &[&str],
+    current_dir: Option<&Path>,
+) -> Result<std::process::Output, String> {
+    // A fresh receiver per command keeps even the kernel's default small
+    // datagram queue from filling while no daemon is draining probe events.
+    let socket = ProbeSocket::bind_with(runtime_dir, temp_dir)?;
+    let mut command = Command::new(ydotool_path);
+    command
+        .args(args)
+        .env("YDOTOOL_SOCKET", &socket.path)
+        // ydotool 1.0.2 swapped the YDOTOOL_SOCKET/XDG_RUNTIME_DIR branches.
+        // Removing XDG_RUNTIME_DIR makes that version fail closed instead of
+        // sending capability-probe events to the user's live daemon.
+        .env_remove("XDG_RUNTIME_DIR")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+    command_output_with_timeout(
+        &mut command,
+        "ydotool capability probe",
+        PROBE_COMMAND_TIMEOUT,
+    )
+}
+
+fn command_output_with_timeout(
+    command: &mut Command,
+    label: &str,
+    timeout_duration: Duration,
+) -> Result<std::process::Output, String> {
+    command_runner::output_blocking_with_timeout(command, label, timeout_duration)
+        .map_err(|error| format!("{error:#}"))
+}
+
+fn probe_socket_bases(runtime_dir: Option<&OsStr>, temp_dir: &Path) -> Vec<PathBuf> {
+    let mut bases = Vec::new();
+    if let Some(runtime_dir) = runtime_dir {
+        push_unique_path(&mut bases, PathBuf::from(runtime_dir));
+    }
+    push_unique_path(&mut bases, temp_dir.to_path_buf());
+    push_unique_path(&mut bases, PathBuf::from("/tmp"));
+    bases
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|candidate| candidate == &path) {
+        paths.push(path);
+    }
+}
+
+fn validate_probe_base(path: &Path, uid: libc::uid_t) -> Result<(), String> {
+    if !path.is_absolute() {
+        return Err("path is not absolute".to_string());
+    }
+    let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err("path is not a real directory".to_string());
+    }
+    let mode = metadata.permissions().mode();
+    let user_owned_safe_directory = metadata.uid() == uid && mode & 0o022 == 0;
+    let root_owned_sticky_directory = metadata.uid() == 0 && mode & libc::S_ISVTX != 0;
+    if !user_owned_safe_directory && !root_owned_sticky_directory {
+        return Err("directory is not private or root-owned sticky".to_string());
+    }
+    Ok(())
+}
+
+fn random_hex(byte_count: usize) -> io::Result<String> {
+    let mut bytes = vec![0_u8; byte_count];
+    getrandom::fill(&mut bytes).map_err(io::Error::other)?;
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(byte_count * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    Ok(output)
+}
+
+fn unix_socket_path_fits(path: &Path) -> bool {
+    path.as_os_str().as_bytes().len() <= MAX_UNIX_SOCKET_PATH_BYTES
+}
+
+fn raw_semantic_probes_succeeded(results: &[(bool, &[u8])]) -> bool {
+    results
+        .iter()
+        .all(|(success, stderr)| *success && cli_error(stderr).is_none())
+}
+
+fn require_semantic_probe(output: &std::process::Output) -> Result<(), String> {
+    if raw_semantic_probes_succeeded(&[(output.status.success(), &output.stderr)]) {
+        Ok(())
+    } else {
+        Err(UNSUPPORTED_MESSAGE.to_string())
+    }
+}
+
+pub(crate) fn classify_help(help: &str) -> Option<CliGeneration> {
+    let commands = help
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let required_raw_commands = ["click", "mousemove", "type", "key", "debug"];
+    if required_raw_commands
+        .iter()
+        .all(|command| commands.contains(command))
+    {
+        Some(CliGeneration::RawEvents)
+    } else if commands.contains(&"recorder") {
+        Some(CliGeneration::LegacyNamed)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn cli_error(stderr: &[u8]) -> Option<String> {
+    let detail = String::from_utf8_lossy(stderr).trim().to_string();
+    let normalized = detail.to_ascii_lowercase();
+    [
+        "unrecognised option",
+        "unrecognized option",
+        "unknown option",
+        "invalid option",
+        "unknown command",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+    .then_some(detail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier,
+    };
+    use std::thread;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let path = env::temp_dir().join(format!(
+                "computer-use-linux-ydotool-{label}-{}-{}",
+                process::id(),
+                random_hex(8).expect("test nonce")
+            ));
+            let mut builder = fs::DirBuilder::new();
+            builder.mode(0o700);
+            builder.create(&path).expect("create test directory");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                .expect("secure test directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn fake_supported_ydotool(root: &Path) -> PathBuf {
+        let path = root.join("ydotool");
+        fs::write(
+            &path,
+            r#"#!/bin/sh
+case "$1" in
+  help|--help)
+    printf '%s\n' \
+      'Usage: ydotool <cmd> <args>' \
+      'Available commands:' \
+      '  click' \
+      '  mousemove' \
+      '  type' \
+      '  key' \
+      '  debug'
+    exit 0
+    ;;
+  *)
+    test -z "${XDG_RUNTIME_DIR+x}" || exit 65
+    printf '%s\n' "$YDOTOOL_SOCKET" >> "${0%/*}/socket-paths"
+    ;;
+esac
+case "$1" in
+  mousemove)
+    test -S "$YDOTOOL_SOCKET" &&
+      { test "$2" = '--wheel' || test "$2" = '--absolute'; } &&
+      test "$3" = '--' && test "$4" = '0' && test "$5" = '0'
+    ;;
+  click)
+    test -S "$YDOTOOL_SOCKET" && test "$2" = '0xC0'
+    ;;
+  key)
+    test -S "$YDOTOOL_SOCKET" && test "$2" = '-d' &&
+      test "$3" = '100' && test "$4" = '1:1' && test "$5" = '1:0'
+    ;;
+  type)
+    test -S "$YDOTOOL_SOCKET" &&
+      test "$2" = '--file' &&
+      test "$3" = '-'
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+"#,
+        )
+        .expect("write fake ydotool");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+            .expect("make fake ydotool executable");
+        path
+    }
+
+    #[test]
+    fn classifies_legacy_named_cli_from_ubuntu_ydotool() {
+        let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  type\n  recorder\n  mousemove\n  key\n  click\n";
+        assert_eq!(classify_help(help), Some(CliGeneration::LegacyNamed));
+    }
+
+    #[test]
+    fn classifies_raw_event_cli_from_current_ydotool() {
+        let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  stdin\n";
+        assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
+    }
+
+    #[test]
+    fn classifies_arch_1_0_4_cli_as_raw_events() {
+        let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  bakers\n";
+        assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
+    }
+
+    #[test]
+    fn accepts_supported_raw_cli_without_xdg_runtime_dir() {
+        let root = TestDirectory::new("no-xdg-cli");
+        let ydotool = fake_supported_ydotool(&root.0);
+
+        assert_eq!(
+            probe_with(&ydotool, None, &root.0),
+            Ok("compatible raw-event CLI detected".to_string())
+        );
+        assert_eq!(
+            fs::read_dir(&root.0)
+                .expect("read test directory")
+                .filter_map(Result::ok)
+                .filter(|entry| entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(PROBE_PREFIX))
+                .count(),
+            0
+        );
+        let socket_paths = fs::read_to_string(root.0.join("socket-paths"))
+            .expect("read recorded probe socket paths")
+            .lines()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let mut unique_paths = socket_paths.clone();
+        unique_paths.sort();
+        unique_paths.dedup();
+        assert_eq!(socket_paths.len(), 5);
+        assert_eq!(unique_paths.len(), 5);
+    }
+
+    #[test]
+    fn capability_probe_commands_are_bounded() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exec sleep 1"]);
+
+        let started = Instant::now();
+        let error =
+            command_output_with_timeout(&mut command, "test probe", Duration::from_millis(20))
+                .unwrap_err();
+
+        assert!(error.contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn capability_probe_kills_descendants_that_hold_output_pipes() {
+        let root = TestDirectory::new("probe-process-group");
+        let pid_path = root.0.join("descendant-pid");
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!("sleep 60 & printf %s $! > '{}'; exit 0", pid_path.display()),
+        ]);
+
+        let error =
+            command_output_with_timeout(&mut command, "test probe", Duration::from_millis(100))
+                .unwrap_err();
+
+        assert!(error.contains("timed out"));
+        let pid = fs::read_to_string(&pid_path)
+            .expect("read descendant pid")
+            .parse::<u32>()
+            .expect("parse descendant pid");
+        wait_for_process_exit(pid);
+    }
+
+    #[test]
+    fn capability_probe_drains_large_output() {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "yes stdout | head -c 200000; yes stderr | head -c 200000 >&2",
+        ]);
+
+        let output =
+            command_output_with_timeout(&mut command, "noisy probe", Duration::from_secs(5))
+                .expect("noisy probe should complete");
+
+        assert!(output.status.success());
+        assert!(output.stdout.len() >= 200_000);
+        assert!(output.stderr.len() >= 200_000);
+    }
+
+    #[test]
+    fn capability_probe_continuous_output_remains_bounded() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exec yes output"]);
+        let started = Instant::now();
+
+        let error =
+            command_output_with_timeout(&mut command, "continuous probe", Duration::from_secs(5))
+                .unwrap_err();
+
+        assert!(error.contains("output exceeded"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn capability_probe_forces_stdin_closed() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "read value && exit 7 || exit 0"]);
+        command.stdin(Stdio::piped());
+
+        let output =
+            command_output_with_timeout(&mut command, "stdin probe", Duration::from_millis(100))
+                .expect("probe stdin should be closed");
+
+        assert!(output.status.success());
+    }
+
+    #[test]
+    fn executable_resolution_uses_one_absolute_path() {
+        let root = TestDirectory::new("resolve-executable");
+        let first = root.0.join("first");
+        let second = root.0.join("second");
+        fs::create_dir_all(&first).expect("create first PATH directory");
+        fs::create_dir_all(&second).expect("create second PATH directory");
+        fs::write(first.join("ydotool"), "not executable").expect("write first candidate");
+        fs::write(second.join("ydotool"), "#!/bin/sh\nexit 0\n").expect("write second candidate");
+        fs::set_permissions(second.join("ydotool"), fs::Permissions::from_mode(0o700))
+            .expect("make second candidate executable");
+        let search_path =
+            env::join_paths([Path::new("first"), Path::new("second")]).expect("join relative PATH");
+
+        let resolved = resolve_executable_with("ydotool", &search_path, Some(&root.0));
+
+        assert_eq!(resolved, Some(second.join("ydotool")));
+    }
+
+    #[test]
+    fn failed_probe_is_temporarily_cached_and_success_is_persistent() {
+        let cache = Mutex::new(None);
+        let attempts = AtomicUsize::new(0);
+        let probe = || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                Err("not installed".to_string())
+            } else {
+                Ok("compatible".to_string())
+            }
+        };
+
+        assert_eq!(
+            cached_result_or_probe(&cache, "first", Duration::from_secs(60), probe),
+            Err("not installed".to_string())
+        );
+        assert_eq!(
+            cached_result_or_probe(&cache, "first", Duration::from_secs(60), probe),
+            Err("not installed".to_string())
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            cached_result_or_probe(&cache, "first", Duration::ZERO, probe),
+            Ok("compatible".to_string())
+        );
+        assert_eq!(
+            cached_result_or_probe(&cache, "first", Duration::ZERO, probe),
+            Ok("compatible".to_string())
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        assert_eq!(
+            cached_result_or_probe(&cache, "replacement", Duration::ZERO, probe),
+            Ok("compatible".to_string())
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn concurrent_capability_probes_are_coalesced() {
+        let cache = Arc::new(Mutex::new(None));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(3));
+        let handles = (0..2)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let attempts = Arc::clone(&attempts);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    cached_result_or_probe(&cache, "same", Duration::from_secs(60), || {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(30));
+                        Ok("compatible".to_string())
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+
+        for handle in handles {
+            assert_eq!(handle.join().unwrap(), Ok("compatible".to_string()));
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn rejects_raw_cli_without_wheel_semantics() {
+        assert!(!raw_semantic_probes_succeeded(&[
+            (true, b""),
+            (true, b"mousemove: unrecognized option '--wheel'\n"),
+        ]));
+    }
+
+    #[test]
+    fn rejects_raw_cli_without_stdin_file_semantics() {
+        assert!(!raw_semantic_probes_succeeded(&[
+            (true, b""),
+            (
+                false,
+                b"ydotool: type: error: failed to open -: No such file or directory\n",
+            ),
+        ]));
+    }
+
+    #[test]
+    fn accepts_raw_cli_with_required_semantics() {
+        assert!(raw_semantic_probes_succeeded(&[
+            (true, b""),
+            (true, b""),
+            (true, b""),
+        ]));
+    }
+
+    #[test]
+    fn rejects_unknown_cli_shape() {
+        assert_eq!(classify_help("Usage: ydotool <cmd>"), None);
+    }
+
+    #[test]
+    fn recognizes_cli_errors_even_when_exit_status_is_success() {
+        assert_eq!(
+            cli_error(b"error: unrecognised option '--absolute'\n"),
+            Some("error: unrecognised option '--absolute'".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_non_error_stderr() {
+        assert_eq!(cli_error(b"ydotoold socket ready\n"), None);
+    }
+
+    fn wait_for_process_exit(pid: u32) {
+        for _ in 0..100 {
+            if !Path::new(&format!("/proc/{pid}")).exists() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        panic!("probe descendant {pid} was not killed")
+    }
+}


### PR DESCRIPTION
## Summary

- add cancellation-safe, timeout-bounded process supervision and exact ydotool executable/capability validation, including no replay through ydotool after xdotool starts
- harden RemoteDesktop portal sessions with serialized initialization/input, complete-desktop monitor validation, coordinate revalidation, bounded D-Bus calls, and cancellation cleanup
- improve exact focus, geometry, and monitor handling across X11/EWMH, KWin, COSMIC, Hyprland, i3, Sway, GNOME, KDE, and XRandR
- align diagnostics, MCP guidance, README, and changelog behavior with runtime backend selection

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`
- `cargo test --all-targets` (211 library tests plus binary and integration targets)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --document-private-items`
- `cargo audit --deny warnings`
- `scripts/mcp_safety_check.py --binary target/debug/computer-use-linux`
- MCP SDK Zod `ListToolsResultSchema` validation for all 18 tools
- `cargo publish --dry-run --locked --allow-dirty`
- npm syntax, wrapper install/help, and `npm pack --dry-run` checks

`agnix` was not available in the local environment; CI remains the validation source for that job.