### PR TITLE
fix: traverse deep GTK4 accessibility trees

### DIFF
--- a/src/atspi_tree.rs
+++ b/src/atspi_tree.rs
@@ -102,6 +102,24 @@ pub enum ValueSetInvocation {
 
 const MAX_TEXT_READBACK_CHARS: i32 = 4096;
 const MAX_TEXT_SELECTIONS: i32 = 8;
+const DEFAULT_SNAPSHOT_MAX_NODES: usize = 1_000;
+const HARD_SNAPSHOT_MAX_NODES: usize = 2_000;
+const DEFAULT_SNAPSHOT_MAX_DEPTH: u32 = 32;
+const HARD_SNAPSHOT_MAX_DEPTH: u32 = 64;
+
+pub(crate) fn snapshot_limits(
+    requested_max_nodes: Option<usize>,
+    requested_max_depth: Option<u32>,
+) -> (usize, u32) {
+    (
+        requested_max_nodes
+            .unwrap_or(DEFAULT_SNAPSHOT_MAX_NODES)
+            .clamp(1, HARD_SNAPSHOT_MAX_NODES),
+        requested_max_depth
+            .unwrap_or(DEFAULT_SNAPSHOT_MAX_DEPTH)
+            .min(HARD_SNAPSHOT_MAX_DEPTH),
+    )
+}
 
 pub async fn list_accessible_apps(limit: usize) -> Result<Vec<AccessibleAppSummary>> {
     let conn = connect().await?;
@@ -747,5 +765,18 @@ mod tests {
         let labels = state_labels(StateSet::new(atspi::State::Focused | atspi::State::Checked));
 
         assert_eq!(labels, vec!["checked".to_string(), "focused".to_string()]);
+    }
+
+    #[test]
+    fn default_snapshot_limits_cover_deep_gtk4_trees() {
+        // Nautilus 50 places file-list cells below depth 20 and can expose
+        // more than 850 raw nodes. Keep the defaults above that known shape.
+        assert_eq!(snapshot_limits(None, None), (1_000, 32));
+    }
+
+    #[test]
+    fn requested_snapshot_limits_remain_bounded() {
+        assert_eq!(snapshot_limits(Some(0), Some(0)), (1, 0));
+        assert_eq!(snapshot_limits(Some(10_000), Some(128)), (2_000, 64));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,9 +35,14 @@ pub(crate) async fn run_from_env() -> Result<()> {
         }
         Some("state") => {
             let app_name_or_bundle_identifier = std::env::args().nth(2);
-            let nodes =
-                atspi_tree::snapshot_tree(app_name_or_bundle_identifier.as_deref(), None, 120, 12)
-                    .await?;
+            let (max_nodes, max_depth) = atspi_tree::snapshot_limits(None, None);
+            let nodes = atspi_tree::snapshot_tree(
+                app_name_or_bundle_identifier.as_deref(),
+                None,
+                max_nodes,
+                max_depth,
+            )
+            .await?;
             println!(
                 "{}",
                 serde_json::to_string_pretty(&nodes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod ydotool;
 pub mod atspi_tree {
     pub(crate) use crate::atspi_tree_impl::{
         focused_element_summary, list_accessible_apps, perform_action, set_element_value,
-        AccessibleAppSummary, FocusedElementSummary, ValueSetInvocation,
+        snapshot_limits, AccessibleAppSummary, FocusedElementSummary, ValueSetInvocation,
     };
     pub use crate::atspi_tree_impl::{
         snapshot_tree, AccessibilityAction, AccessibilityNode, AccessibilityText,

--- a/src/server.rs
+++ b/src/server.rs
@@ -302,8 +302,8 @@ impl ComputerUseLinux {
             .expect("diagnostics task panicked");
         let (window_context, window_error, window_permissions_hint) =
             self.resolve_window_context(&params).await;
-        let max_nodes = params.max_nodes.unwrap_or(120).clamp(1, 500);
-        let max_depth = params.max_depth.unwrap_or(12).min(12);
+        let (max_nodes, max_depth) =
+            crate::atspi_tree::snapshot_limits(params.max_nodes, params.max_depth);
         let include_screenshot = params.include_screenshot.unwrap_or(true);
         let screenshot_options = params.screenshot_options();
         let screenshot_target_requested = params.window_target().has_target();
@@ -1845,8 +1845,10 @@ struct GetAppStateParams {
     wm_class: Option<String>,
     #[serde(default)]
     title: Option<String>,
+    /// Maximum raw AT-SPI nodes to inspect before compaction (default 1000, hard max 2000).
     #[serde(default)]
     max_nodes: Option<usize>,
+    /// Maximum AT-SPI traversal depth (default 32, hard max 64).
     #[serde(default)]
     max_depth: Option<u32>,
     #[serde(default)]


### PR DESCRIPTION
## Summary

- raise the default raw AT-SPI snapshot budget from 120 to 1,000 nodes, with a 2,000-node hard cap
- raise the default traversal depth from 12 to 32, with a depth-64 hard cap
- use the same bounded limits for the MCP `get_app_state` tool and CLI `state` command
- document the limits in the MCP schema and cover the Nautilus 50 boundary with regression tests

## Root cause

Nautilus 50's GTK4 accessibility tree places its file-list cells well below the old depth-12 cutoff. On the matching Ubuntu 26.04 / GNOME 50.1 / Nautilus 50.0 environment, the old walk stopped after 33 raw nodes and never reached the actionable descendants. The first file cells appear at depth 23, and the complete local tree reaches depth 29 with 606 raw nodes.

The existing GTK4 proxy-destination fix from #31 is working; this was a separate traversal-limit issue. Compaction only had high-level nodes available because the raw walk had already stopped.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --no-fail-fast` (237 library tests, 7 helper tests, 1 integration test)
- `cargo clippy --locked --all-targets -- -D warnings`
- `scripts/mcp_safety_check.py --binary target/debug/computer-use-linux`
- `node scripts/zod-check/check.mjs --command target/debug/computer-use-linux`
- `npm pack --dry-run`
- live MCP smoke on Ubuntu 26.04, GNOME Shell 50.1, Nautilus 50.0: `get_app_state` returned 271 compacted nodes from 606 raw nodes, including 76 named grid cells, with no accessibility error

Closes #85
