### PR TITLE
feat: add opt-in bounded shell execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- An explicitly opt-in `run_shell` MCP tool supports bounded same-user shell
+  execution for trusted remote MCP deployments. The tool is absent unless
+  `COMPUTER_USE_LINUX_ENABLE_SHELL=1`, clears ambient credentials, requires
+  visible environment additions, enforces timeout/output limits and process-
+  group cleanup, and emits command-digest audit records.
+
 ## [0.4.10] - 2026-08-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +339,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "wayland-client",
  "wayland-protocols",
@@ -346,6 +356,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -368,6 +384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +406,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "darling"
@@ -414,6 +448,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -692,6 +737,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1198,6 +1252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1469,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rmcp = { version = "1.5.0", features = ["transport-io"] }
 schemars = "1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+sha2 = "0.11.0"
 tokio = { version = "1.51.1", features = ["io-util", "macros", "process", "rt", "sync", "time"] }
 wayland-client = "0.31.11"
 wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Targeted `press_key`/`type_text` results append focused-element feedback from AT
 
 **Conditional host execution**
 
-- `run_shell` — same-user `/bin/sh -lc` execution, registered only when the server operator starts the MCP process with `COMPUTER_USE_LINUX_ENABLE_SHELL=1`. It is deliberately absent by default and is not a sandbox.
+- `run_shell` — same-user `/bin/sh -c` execution without login-profile loading, registered only when the server operator starts the MCP process with `COMPUTER_USE_LINUX_ENABLE_SHELL=1`. It is deliberately absent by default and is not a sandbox.
 
 ### MCP safety contract
 
@@ -89,7 +89,7 @@ Targeted `press_key`/`type_text` results append focused-element feedback from AT
 
 Annotations are safety hints, not an authorization system. MCP hosts should still ask the user before calls that could submit, delete, send, purchase, overwrite, or otherwise commit state.
 
-`run_shell` is an explicit trust-boundary opt-in, not a restricted command runner. Enabling it grants an approved MCP call the same file and network authority as the user running the server. The tool clears the ambient environment and inherits only a small desktop/runtime allowlist (`PATH`, home/user/locale fields, display/session-bus fields); additional variables must be supplied in the visible call payload. Commands use a fixed `/bin/sh`, an existing canonical working directory, a 30-second default / 120-second hard timeout, process-group cleanup, bounded collection, 512 KiB per returned stream, and stderr audit records keyed by the command SHA-256 rather than command text. These controls bound accidental leakage and runaway work; they do not make arbitrary shell code safe.
+`run_shell` is an explicit trust-boundary opt-in, not a restricted command runner. Enabling it grants an approved MCP call the same file and network authority as the user running the server. The tool clears the ambient environment and inherits only a small desktop/runtime allowlist (`PATH`, home/user/locale fields, display/session-bus fields); additional variables must be supplied in the visible call payload. Commands use a fixed non-login `/bin/sh`, an existing canonical working directory, a 30-second default / 120-second hard timeout, process-group cleanup, and stderr audit records keyed by the command SHA-256 rather than command text. Collected streams up to 8 MiB are returned with a 512 KiB per-stream response cap and truncation flag; exceeding 8 MiB on either stream fails the call without partial output. These controls bound accidental leakage and runaway work; they do not make arbitrary shell code safe.
 
 The binary also exposes the same capabilities from the CLI for scripting and debugging:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Targeted `press_key`/`type_text` results append focused-element feedback from AT
 - `activate_window` — focus a window by `window_id`, `pid`, `app_id`, `wm_class`, `title`, or terminal selectors
 - `move_window` / `resize_window` — reposition or resize a window in desktop coordinates (GNOME Shell extension backend); useful to recover windows that are partially off-screen
 
+**Conditional host execution**
+
+- `run_shell` — same-user `/bin/sh -lc` execution, registered only when the server operator starts the MCP process with `COMPUTER_USE_LINUX_ENABLE_SHELL=1`. It is deliberately absent by default and is not a sandbox.
+
 ### MCP safety contract
 
 `computer-use-linux` is not a read-only data source. It can observe the local desktop and, when a mutating tool is called, can change real application state. The `tools/list` response includes MCP `ToolAnnotations` so hosts can surface this distinction before invocation:
@@ -81,8 +85,11 @@ Targeted `press_key`/`type_text` results append focused-element feedback from AT
 | Local setup mutators | `setup_accessibility`, `setup_window_targeting` | `readOnlyHint=false`, `destructiveHint=false`, `idempotentHint=true`; modifies user desktop configuration by enabling accessibility or installing/enabling the GNOME window-targeting extension. |
 | UI state mutators | `activate_window`, `move_window`, `resize_window`, `scroll`, `screenshot` | `readOnlyHint=false`, `destructiveHint=false`; changes focus, geometry, or scroll position in the live desktop, or raises a window to capture it. |
 | Desktop action mutators | `click`, `drag`, `press_key`, `type_text`, `perform_action`, `set_value` | `readOnlyHint=false`, `destructiveHint=true`, `openWorldHint=true`; can trigger arbitrary actions in whatever local application is targeted. |
+| Conditional host-code execution | `run_shell` | Absent unless `COMPUTER_USE_LINUX_ENABLE_SHELL=1`; when enabled, `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=true`. Runs with the MCP server user's host permissions. |
 
 Annotations are safety hints, not an authorization system. MCP hosts should still ask the user before calls that could submit, delete, send, purchase, overwrite, or otherwise commit state.
+
+`run_shell` is an explicit trust-boundary opt-in, not a restricted command runner. Enabling it grants an approved MCP call the same file and network authority as the user running the server. The tool clears the ambient environment and inherits only a small desktop/runtime allowlist (`PATH`, home/user/locale fields, display/session-bus fields); additional variables must be supplied in the visible call payload. Commands use a fixed `/bin/sh`, an existing canonical working directory, a 30-second default / 120-second hard timeout, process-group cleanup, bounded collection, 512 KiB per returned stream, and stderr audit records keyed by the command SHA-256 rather than command text. These controls bound accidental leakage and runaway work; they do not make arbitrary shell code safe.
 
 The binary also exposes the same capabilities from the CLI for scripting and debugging:
 
@@ -340,6 +347,7 @@ Most setups need none of these — `doctor` and the installers pick sensible def
 | `COMPUTER_USE_LINUX_FORCE_YDOTOOL_POINTER` / `…_KEYBOARD` | Always route pointer / keyboard through `ydotool`, skipping the portal and KDE clipboard paths; pointer forcing also skips native-X11 `xdotool` coordinate clicks. |
 | `COMPUTER_USE_LINUX_FORCE_XDOTOOL_KEYBOARD` | Prefer `xdotool`/XTEST keyboard input when `DISPLAY` is available. `COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD=1` takes precedence. |
 | `COMPUTER_USE_LINUX_SCREENSHOT_BACKEND` | Force a single screenshot backend, skipping the fallback chain. Accepts `gnome-shell`, `portal`, or `gnome-screenshot`. Pin `gnome-screenshot` for background/systemd contexts where the GNOME Shell and portal DBus paths are denied. |
+| `COMPUTER_USE_LINUX_ENABLE_SHELL` | Set exactly to `1` before starting the MCP server to register the destructive `run_shell` tool. Unset by default. Do not enable for untrusted or unattended MCP hosts. |
 
 **Build-time identity overrides** (set while compiling a downstream embedded
 bundle): `CUL_GNOME_EXTENSION_UUID`, `CUL_DBUS_SERVICE`, and

--- a/scripts/mcp_safety_check.py
+++ b/scripts/mcp_safety_check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 import re
 import select
@@ -33,6 +34,7 @@ EXPECTED_TOOLS = {
     "perform_action",
     "set_value",
 }
+SHELL_TOOL = "run_shell"
 
 INJECTION_PATTERNS = [
     re.compile(pattern, re.IGNORECASE)
@@ -54,6 +56,7 @@ DANGEROUS_TOOL_NAMES = {
     "eval",
     "shell",
     "run_command",
+    SHELL_TOOL,
     "terminal",
     "read_file",
     "write_file",
@@ -97,6 +100,7 @@ DESTRUCTIVE_MUTATING_TOOLS = {
     "type_text",
     "perform_action",
     "set_value",
+    SHELL_TOOL,
 }
 
 NON_DESTRUCTIVE_MUTATING_TOOLS = EXPECTED_TOOLS - READ_ONLY_TOOLS - DESTRUCTIVE_MUTATING_TOOLS
@@ -109,7 +113,7 @@ IDEMPOTENT_TOOLS = READ_ONLY_TOOLS | {
     "resize_window",
 }
 
-OPEN_WORLD_TOOLS = EXPECTED_TOOLS - {
+OPEN_WORLD_TOOLS = (EXPECTED_TOOLS | {SHELL_TOOL}) - {
     "doctor",
     "setup_accessibility",
     "setup_window_targeting",
@@ -117,7 +121,10 @@ OPEN_WORLD_TOOLS = EXPECTED_TOOLS - {
 
 
 class McpClient:
-    def __init__(self, binary: pathlib.Path):
+    def __init__(self, binary: pathlib.Path, extra_env: dict[str, str] | None = None):
+        child_env = os.environ.copy()
+        if extra_env:
+            child_env.update(extra_env)
         self.process = subprocess.Popen(
             [str(binary), "mcp"],
             stdin=subprocess.PIPE,
@@ -125,6 +132,7 @@ class McpClient:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            env=child_env,
         )
         self.next_id = 1
 
@@ -239,7 +247,9 @@ def main() -> int:
         raise AssertionError(f"binary does not exist: {binary}")
 
     version = package_version(repo)
-    annotation_partition = READ_ONLY_TOOLS | NON_DESTRUCTIVE_MUTATING_TOOLS | DESTRUCTIVE_MUTATING_TOOLS
+    annotation_partition = (
+        READ_ONLY_TOOLS | NON_DESTRUCTIVE_MUTATING_TOOLS | DESTRUCTIVE_MUTATING_TOOLS
+    ) - {SHELL_TOOL}
     if annotation_partition != EXPECTED_TOOLS:
         raise AssertionError(
             "tool annotation classes do not cover the expected MCP tool set: "
@@ -288,13 +298,13 @@ def main() -> int:
             name = tool["name"]
             if not re.fullmatch(r"[a-z][a-z0-9_]*", name):
                 raise AssertionError(f"tool name is not provider-safe snake_case: {name!r}")
-            if name in DANGEROUS_TOOL_NAMES:
+            if name in DANGEROUS_TOOL_NAMES and name != SHELL_TOOL:
                 raise AssertionError(f"unexpected dangerous tool name exposed: {name}")
             description = tool.get("description") or ""
             assert_no_injection_text(f"{name} description", description)
             assert_tool_annotations(tool)
             props = schema_properties(tool)
-            if "env" in props or "shell" in props or "command" in props:
+            if name != SHELL_TOOL and ("env" in props or "shell" in props or "command" in props):
                 raise AssertionError(f"{name} exposes a raw process-control parameter: {sorted(props)}")
             if name in {"press_key", "type_text", "activate_window"} and not FOCUS_SELECTORS <= props:
                 raise AssertionError(f"{name} is missing focus target selectors: {sorted(FOCUS_SELECTORS - props)}")
@@ -314,7 +324,65 @@ def main() -> int:
     finally:
         client.close()
 
-    print(f"MCP safety check passed: {len(EXPECTED_TOOLS)} tools, version {version}")
+    shell_client = McpClient(
+        binary,
+        {
+            "COMPUTER_USE_LINUX_ENABLE_SHELL": "1",
+            "COMPUTER_USE_LINUX_TEST_SECRET": "must-not-be-inherited",
+        },
+    )
+    try:
+        shell_client.request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "computer-use-linux-shell-ci", "version": "0"},
+            },
+        )
+        shell_client.notify("notifications/initialized", {})
+        tools = shell_client.request("tools/list", {})["result"].get("tools") or []
+        names = {tool.get("name") for tool in tools}
+        expected = EXPECTED_TOOLS | {SHELL_TOOL}
+        if names != expected:
+            raise AssertionError(
+                f"unexpected opt-in tools: missing={expected - names}, extra={names - expected}"
+            )
+        shell_tool = next(tool for tool in tools if tool.get("name") == SHELL_TOOL)
+        assert_tool_annotations(shell_tool)
+        shell_props = schema_properties(shell_tool)
+        required_shell_props = {"command", "cwd", "env", "timeout_seconds"}
+        if not required_shell_props <= shell_props:
+            raise AssertionError(
+                f"{SHELL_TOOL} is missing bounded execution controls: {sorted(required_shell_props - shell_props)}"
+            )
+        result = shell_client.request(
+            "tools/call",
+            {
+                "name": SHELL_TOOL,
+                "arguments": {
+                    "command": 'test -z "${COMPUTER_USE_LINUX_TEST_SECRET-}" && printf %s "$EXPLICIT"',
+                    "cwd": str(repo),
+                    "env": {"EXPLICIT": "shell-ok"},
+                    "timeout_seconds": 5,
+                },
+            },
+        )["result"]
+        content = result.get("content") or []
+        if not content or content[0].get("type") != "text":
+            raise AssertionError(f"{SHELL_TOOL} did not return text content: {result!r}")
+        shell_result = json.loads(content[0].get("text") or "{}")
+        if shell_result.get("ok") is not True or shell_result.get("stdout") != "shell-ok":
+            raise AssertionError(f"{SHELL_TOOL} smoke failed: {shell_result!r}")
+        if len(shell_result.get("command_sha256") or "") != 64:
+            raise AssertionError(f"{SHELL_TOOL} did not return an audit digest: {shell_result!r}")
+    finally:
+        shell_client.close()
+
+    print(
+        f"MCP safety check passed: {len(EXPECTED_TOOLS)} default tools, "
+        f"{len(EXPECTED_TOOLS) + 1} with shell opt-in, version {version}"
+    )
     return 0
 
 

--- a/scripts/mcp_safety_check.py
+++ b/scripts/mcp_safety_check.py
@@ -11,6 +11,7 @@ import re
 import select
 import subprocess
 import sys
+import tempfile
 from typing import Any
 
 
@@ -324,11 +325,17 @@ def main() -> int:
     finally:
         client.close()
 
+    shell_home = tempfile.TemporaryDirectory(prefix="computer-use-linux-shell-home-")
+    pathlib.Path(shell_home.name, ".profile").write_text(
+        "export COMPUTER_USE_LINUX_PROFILE_SECRET=must-not-be-loaded\n",
+        encoding="utf-8",
+    )
     shell_client = McpClient(
         binary,
         {
             "COMPUTER_USE_LINUX_ENABLE_SHELL": "1",
             "COMPUTER_USE_LINUX_TEST_SECRET": "must-not-be-inherited",
+            "HOME": shell_home.name,
         },
     )
     try:
@@ -361,7 +368,7 @@ def main() -> int:
             {
                 "name": SHELL_TOOL,
                 "arguments": {
-                    "command": 'test -z "${COMPUTER_USE_LINUX_TEST_SECRET-}" && printf %s "$EXPLICIT"',
+                    "command": 'test -z "${COMPUTER_USE_LINUX_TEST_SECRET-}" && test -z "${COMPUTER_USE_LINUX_PROFILE_SECRET-}" && printf %s "$EXPLICIT"',
                     "cwd": str(repo),
                     "env": {"EXPLICIT": "shell-ok"},
                     "timeout_seconds": 5,
@@ -378,6 +385,7 @@ def main() -> int:
             raise AssertionError(f"{SHELL_TOOL} did not return an audit digest: {shell_result!r}")
     finally:
         shell_client.close()
+        shell_home.cleanup()
 
     print(
         f"MCP safety check passed: {len(EXPECTED_TOOLS)} default tools, "

--- a/src/server.rs
+++ b/src/server.rs
@@ -1509,7 +1509,7 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "run_shell",
-        description = "Execute one explicitly approved /bin/sh command with same-user host authority. This tool is absent unless the server operator starts computer-use-linux with COMPUTER_USE_LINUX_ENABLE_SHELL=1. It is not sandboxed: the command can read or modify files and use the network with the server user's permissions. The inherited environment is cleared to a small desktop/runtime allowlist; pass any additional variables explicitly. Execution time and returned output are bounded, and an audit digest is written to server stderr.",
+        description = "Execute one explicitly approved /bin/sh command with same-user host authority. This tool is absent unless the server operator starts computer-use-linux with COMPUTER_USE_LINUX_ENABLE_SHELL=1. It is not sandboxed: the command can read or modify files and use the network with the server user's permissions. The inherited environment is cleared to a small desktop/runtime allowlist; pass any additional variables explicitly. Execution time and output are bounded: returned streams are truncated to 512 KiB, while a stream exceeding the 8 MiB collection ceiling fails the call without returning partial output. An audit digest is written to server stderr.",
         annotations(
             read_only_hint = false,
             destructive_hint = true,
@@ -1906,7 +1906,9 @@ async fn execute_shell(params: RunShellParams) -> RunShellOutput {
     let cwd_display = cwd.display().to_string();
 
     let mut child = TokioCommand::new("/bin/sh");
-    child.args(["-lc", &params.command]);
+    // Do not use a login shell: profile scripts could reintroduce credentials
+    // after env_clear() and contaminate or prevent the requested command.
+    child.args(["-c", &params.command]);
     child.current_dir(&cwd);
     child.env_clear();
     let mut inherited_path = false;
@@ -2085,7 +2087,7 @@ struct WindowGeometryOutput {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 struct RunShellParams {
-    /// Shell program text passed to `/bin/sh -lc`.
+    /// Shell program text passed to `/bin/sh -c` without loading login profiles.
     command: String,
     /// Existing directory in which to start the shell. Symlinks are resolved.
     #[serde(default)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,7 @@ use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeMap,
     env,
+    ffi::OsString,
     future::Future,
     os::unix::net::UnixDatagram,
     path::{Path, PathBuf},
@@ -1755,6 +1756,20 @@ fn inherited_shell_environment_allowed(name: &str) -> bool {
     ) || name.starts_with("LC_")
 }
 
+fn inherited_shell_environment(
+    variables: impl IntoIterator<Item = (OsString, OsString)>,
+) -> Vec<(String, String)> {
+    variables
+        .into_iter()
+        .filter_map(|(name, value)| {
+            let (Ok(name), Ok(value)) = (name.into_string(), value.into_string()) else {
+                return None;
+            };
+            inherited_shell_environment_allowed(&name).then_some((name, value))
+        })
+        .collect()
+}
+
 fn shell_command_sha256(command: &str) -> String {
     Sha256::digest(command.as_bytes())
         .iter()
@@ -1895,11 +1910,9 @@ async fn execute_shell(params: RunShellParams) -> RunShellOutput {
     child.current_dir(&cwd);
     child.env_clear();
     let mut inherited_path = false;
-    for (name, value) in env::vars() {
-        if inherited_shell_environment_allowed(&name) {
-            inherited_path |= name == "PATH";
-            child.env(name, value);
-        }
+    for (name, value) in inherited_shell_environment(env::vars_os()) {
+        inherited_path |= name == "PATH";
+        child.env(name, value);
     }
     if !inherited_path {
         child.env("PATH", "/usr/local/bin:/usr/bin:/bin");
@@ -6899,6 +6912,23 @@ mod tests {
         ] {
             assert!(!inherited_shell_environment_allowed(secret));
         }
+    }
+
+    #[test]
+    fn shell_environment_skips_non_utf8_entries() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let variables = [
+            (OsString::from("PATH"), OsString::from("/usr/bin")),
+            (OsString::from_vec(vec![0xff]), OsString::from("ignored")),
+            (OsString::from("LANG"), OsString::from_vec(vec![0xff])),
+            (OsString::from("GITHUB_TOKEN"), OsString::from("secret")),
+        ];
+
+        assert_eq!(
+            inherited_shell_environment(variables),
+            vec![("PATH".to_string(), "/usr/bin".to_string())]
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -30,7 +30,9 @@ use rmcp::{
     tool, tool_handler, tool_router, ErrorData, ServerHandler, ServiceExt,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::{
+    collections::BTreeMap,
     env,
     future::Future,
     os::unix::net::UnixDatagram,
@@ -51,6 +53,14 @@ const KDE_CLIPBOARD_DBUS_TIMEOUT: Duration = Duration::from_secs(3);
 const KDE_KLIPPER_SERVICE: &str = "org.kde.klipper";
 const KDE_KLIPPER_PATH: &str = "/klipper";
 const KDE_KLIPPER_INTERFACE: &str = "org.kde.klipper.klipper";
+const SHELL_ENABLE_ENV: &str = "COMPUTER_USE_LINUX_ENABLE_SHELL";
+const SHELL_DEFAULT_TIMEOUT_SECS: u64 = 30;
+const SHELL_MAX_TIMEOUT_SECS: u64 = 120;
+const SHELL_MAX_COMMAND_BYTES: usize = 64 * 1024;
+const SHELL_MAX_CWD_BYTES: usize = 4096;
+const SHELL_MAX_ENV_ENTRIES: usize = 64;
+const SHELL_MAX_ENV_BYTES: usize = 64 * 1024;
+const SHELL_RESPONSE_STREAM_BYTES: usize = 512 * 1024;
 
 #[derive(Clone, Default)]
 pub struct ComputerUseLinux {
@@ -96,6 +106,9 @@ fn sanitize_unsigned_integer_formats(value: &mut serde_json::Value) {
 impl ComputerUseLinux {
     fn mcp_tool_router(&self) -> rmcp::handler::server::router::tool::ToolRouter<Self> {
         let mut router = Self::tool_router();
+        if !shell_execution_enabled() {
+            router.map.remove("run_shell");
+        }
         for route in router.map.values_mut() {
             let input_schema = Arc::make_mut(&mut route.attr.input_schema);
             for value in input_schema.values_mut() {
@@ -1494,6 +1507,23 @@ impl ComputerUseLinux {
     }
 
     #[tool(
+        name = "run_shell",
+        description = "Execute one explicitly approved /bin/sh command with same-user host authority. This tool is absent unless the server operator starts computer-use-linux with COMPUTER_USE_LINUX_ENABLE_SHELL=1. It is not sandboxed: the command can read or modify files and use the network with the server user's permissions. The inherited environment is cleared to a small desktop/runtime allowlist; pass any additional variables explicitly. Execution time and returned output are bounded, and an audit digest is written to server stderr.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
+    )]
+    async fn run_shell(
+        &self,
+        Parameters(params): Parameters<RunShellParams>,
+    ) -> Json<RunShellOutput> {
+        Json(execute_shell(params).await)
+    }
+
+    #[tool(
         name = "type_text",
         description = "Type literal text using keyboard input, optionally after focusing a target window or terminal selector.",
         annotations(
@@ -1693,6 +1723,231 @@ impl ComputerUseLinux {
 )]
 impl ServerHandler for ComputerUseLinux {}
 
+fn shell_execution_enabled() -> bool {
+    shell_execution_enabled_value(env::var(SHELL_ENABLE_ENV).ok().as_deref())
+}
+
+fn shell_execution_enabled_value(value: Option<&str>) -> bool {
+    value == Some("1")
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn inherited_shell_environment_allowed(name: &str) -> bool {
+    matches!(
+        name,
+        "PATH"
+            | "HOME"
+            | "USER"
+            | "LOGNAME"
+            | "LANG"
+            | "TERM"
+            | "XDG_RUNTIME_DIR"
+            | "DISPLAY"
+            | "WAYLAND_DISPLAY"
+            | "DBUS_SESSION_BUS_ADDRESS"
+    ) || name.starts_with("LC_")
+}
+
+fn shell_command_sha256(command: &str) -> String {
+    Sha256::digest(command.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn bounded_shell_stream(bytes: &[u8]) -> (String, bool) {
+    let truncated = bytes.len() > SHELL_RESPONSE_STREAM_BYTES;
+    let visible = if truncated {
+        &bytes[..SHELL_RESPONSE_STREAM_BYTES]
+    } else {
+        bytes
+    };
+    (String::from_utf8_lossy(visible).into_owned(), truncated)
+}
+
+fn shell_error_output(
+    command_sha256: String,
+    cwd: String,
+    timeout_seconds: u64,
+    error: impl Into<String>,
+) -> RunShellOutput {
+    RunShellOutput {
+        ok: false,
+        command_sha256,
+        cwd,
+        timeout_seconds,
+        exit_code: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        error: Some(error.into()),
+    }
+}
+
+async fn execute_shell(params: RunShellParams) -> RunShellOutput {
+    let command_sha256 = shell_command_sha256(&params.command);
+    let timeout_seconds = params.timeout_seconds.unwrap_or(SHELL_DEFAULT_TIMEOUT_SECS);
+    let requested_cwd = params.cwd.as_deref().unwrap_or(".").to_string();
+
+    if !shell_execution_enabled() {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            format!(
+                "shell execution is disabled; restart the MCP server with {SHELL_ENABLE_ENV}=1 to opt in"
+            ),
+        );
+    }
+    if params.command.trim().is_empty() {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            "command must not be empty",
+        );
+    }
+    if params.command.len() > SHELL_MAX_COMMAND_BYTES {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            format!("command exceeds the {SHELL_MAX_COMMAND_BYTES}-byte limit"),
+        );
+    }
+    if requested_cwd.len() > SHELL_MAX_CWD_BYTES {
+        return shell_error_output(
+            command_sha256,
+            "<rejected: cwd too long>".to_string(),
+            timeout_seconds,
+            format!("cwd exceeds the {SHELL_MAX_CWD_BYTES}-byte limit"),
+        );
+    }
+    if !(1..=SHELL_MAX_TIMEOUT_SECS).contains(&timeout_seconds) {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            format!("timeout_seconds must be between 1 and {SHELL_MAX_TIMEOUT_SECS}"),
+        );
+    }
+    if params.env.len() > SHELL_MAX_ENV_ENTRIES {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            format!("env contains more than {SHELL_MAX_ENV_ENTRIES} entries"),
+        );
+    }
+    let env_bytes = params
+        .env
+        .iter()
+        .map(|(name, value)| name.len().saturating_add(value.len()))
+        .sum::<usize>();
+    if env_bytes > SHELL_MAX_ENV_BYTES {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            format!("env exceeds the {SHELL_MAX_ENV_BYTES}-byte limit"),
+        );
+    }
+    if let Some(invalid) = params.env.keys().find(|name| !valid_environment_name(name)) {
+        return shell_error_output(
+            command_sha256,
+            requested_cwd,
+            timeout_seconds,
+            format!("invalid environment variable name: {invalid}"),
+        );
+    }
+
+    let cwd = match std::fs::canonicalize(&requested_cwd) {
+        Ok(path) if path.is_dir() => path,
+        Ok(_) => {
+            return shell_error_output(
+                command_sha256,
+                requested_cwd,
+                timeout_seconds,
+                "cwd is not a directory",
+            )
+        }
+        Err(error) => {
+            return shell_error_output(
+                command_sha256,
+                requested_cwd,
+                timeout_seconds,
+                format!("failed to resolve cwd: {error}"),
+            )
+        }
+    };
+    let cwd_display = cwd.display().to_string();
+
+    let mut child = TokioCommand::new("/bin/sh");
+    child.args(["-lc", &params.command]);
+    child.current_dir(&cwd);
+    child.env_clear();
+    let mut inherited_path = false;
+    for (name, value) in env::vars() {
+        if inherited_shell_environment_allowed(&name) {
+            inherited_path |= name == "PATH";
+            child.env(name, value);
+        }
+    }
+    if !inherited_path {
+        child.env("PATH", "/usr/local/bin:/usr/bin:/bin");
+    }
+    child.envs(&params.env);
+
+    eprintln!(
+        "[computer-use-linux] run_shell start sha256={command_sha256} cwd={cwd_display:?} timeout_seconds={timeout_seconds}"
+    );
+    match crate::command_runner::output_with_timeout(
+        child,
+        "run approved shell command",
+        Duration::from_secs(timeout_seconds),
+    )
+    .await
+    {
+        Ok(output) => {
+            let exit_code = output.status.code();
+            let (stdout, stdout_truncated) = bounded_shell_stream(&output.stdout);
+            let (stderr, stderr_truncated) = bounded_shell_stream(&output.stderr);
+            eprintln!(
+                "[computer-use-linux] run_shell finish sha256={command_sha256} exit_code={exit_code:?} stdout_bytes={} stderr_bytes={} stdout_truncated={stdout_truncated} stderr_truncated={stderr_truncated}",
+                output.stdout.len(),
+                output.stderr.len()
+            );
+            RunShellOutput {
+                ok: output.status.success(),
+                command_sha256,
+                cwd: cwd_display,
+                timeout_seconds,
+                exit_code,
+                stdout,
+                stderr,
+                stdout_truncated,
+                stderr_truncated,
+                error: None,
+            }
+        }
+        Err(error) => {
+            let error = format!("{error:#}");
+            eprintln!(
+                "[computer-use-linux] run_shell error sha256={command_sha256} error={error:?}"
+            );
+            shell_error_output(command_sha256, cwd_display, timeout_seconds, error)
+        }
+    }
+}
+
 pub async fn serve_mcp() -> Result<()> {
     ComputerUseLinux::default()
         .serve(rmcp::transport::stdio())
@@ -1813,6 +2068,35 @@ struct WindowGeometryOutput {
     permissions_hint: Option<String>,
     #[schemars(skip)]
     received: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+struct RunShellParams {
+    /// Shell program text passed to `/bin/sh -lc`.
+    command: String,
+    /// Existing directory in which to start the shell. Symlinks are resolved.
+    #[serde(default)]
+    cwd: Option<String>,
+    /// Additional environment entries. The ambient process environment is not inherited wholesale.
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    /// Wall-clock timeout in seconds (default 30, maximum 120).
+    #[serde(default)]
+    timeout_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct RunShellOutput {
+    ok: bool,
+    command_sha256: String,
+    cwd: String,
+    timeout_seconds: u64,
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -6582,5 +6866,71 @@ mod tests {
         assert!(
             apply_window_relative_scroll_coordinates(&mut params, (100, 200, 800, 600)).is_err()
         );
+    }
+
+    #[test]
+    fn shell_execution_requires_exact_operator_opt_in() {
+        assert!(shell_execution_enabled_value(Some("1")));
+        for value in [None, Some(""), Some("0"), Some("true"), Some("yes")] {
+            assert!(!shell_execution_enabled_value(value));
+        }
+    }
+
+    #[test]
+    fn shell_environment_policy_excludes_ambient_credentials() {
+        for allowed in [
+            "PATH",
+            "HOME",
+            "LANG",
+            "LC_ALL",
+            "XDG_RUNTIME_DIR",
+            "DISPLAY",
+            "WAYLAND_DISPLAY",
+            "DBUS_SESSION_BUS_ADDRESS",
+        ] {
+            assert!(inherited_shell_environment_allowed(allowed));
+        }
+        for secret in [
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_TOKEN",
+            "OPENAI_API_KEY",
+            "SSH_AUTH_SOCK",
+            "LD_PRELOAD",
+        ] {
+            assert!(!inherited_shell_environment_allowed(secret));
+        }
+    }
+
+    #[test]
+    fn shell_environment_names_follow_exec_rules() {
+        for valid in ["A", "_PRIVATE", "NAME_2"] {
+            assert!(valid_environment_name(valid));
+        }
+        for invalid in ["", "2FAST", "BAD-NAME", "A=B", "naïve"] {
+            assert!(!valid_environment_name(invalid));
+        }
+    }
+
+    #[test]
+    fn shell_output_is_bounded_before_mcp_serialization() {
+        let oversized = vec![b'x'; SHELL_RESPONSE_STREAM_BYTES + 17];
+        let (visible, truncated) = bounded_shell_stream(&oversized);
+        assert!(truncated);
+        assert_eq!(visible.len(), SHELL_RESPONSE_STREAM_BYTES);
+
+        let (visible, truncated) = bounded_shell_stream(b"ok");
+        assert!(!truncated);
+        assert_eq!(visible, "ok");
+    }
+
+    #[test]
+    fn shell_audit_digest_is_stable_and_does_not_echo_command_text() {
+        let digest = shell_command_sha256("printf secret");
+        assert_eq!(digest.len(), 64);
+        assert!(digest
+            .chars()
+            .all(|character| character.is_ascii_hexdigit()));
+        assert!(!digest.contains("secret"));
+        assert_eq!(digest, shell_command_sha256("printf secret"));
     }
 }


### PR DESCRIPTION
## Summary
- add a run_shell MCP tool for trusted remote MCP deployments
- keep the tool absent by default; register it only when the operator starts the server with COMPUTER_USE_LINUX_ENABLE_SHELL=1
- execute through fixed /bin/sh with a canonical cwd, cleared/minimal inherited environment, visible explicit env additions, bounded timeout/output, process-group cleanup, and SHA-256 audit records
- mark the tool destructive, non-idempotent, and open-world; document that it is same-user arbitrary code execution, not a sandbox
- extend the MCP safety gate to prove the default surface remains 18 tools, the opt-in surface is 19, ambient test secrets are excluded, and explicit env values work

Closes #99

## Threat model
The realistic attacker controls MCP tool arguments through untrusted model/context input but cannot set the server process environment. The security invariant is that discovery alone never grants process execution. Operator opt-in plus host approval are prerequisites; after both, same-user file and network access is intended authority, while default exposure, ambient credential inheritance, unbounded execution/output, or failed process-tree cleanup remain security defects.

## Verification
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `python3 scripts/mcp_safety_check.py --binary target/debug/computer-use-linux --repo .`
- `cargo fmt --all -- --check`
- `git diff --check`