### PR TITLE
fix: use terminal paste shortcuts on KDE Plasma

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,7 @@ use crate::screenshot::{
     capture_screenshot_raw, prepare_screenshot_payload, RawScreenshotCapture, ScreenshotCapture,
     ScreenshotOutputFormat, ScreenshotPayloadOptions,
 };
+use crate::terminal::uses_terminal_paste_shortcut;
 use crate::windowing::registry;
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
@@ -1540,7 +1541,8 @@ impl ComputerUseLinux {
     ) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
         let input_guard = Arc::clone(&self.input_operation_lock).lock_owned().await;
-        let focus = match self.focus_target_for_input(&params.window_target()).await {
+        let window_target = params.window_target();
+        let focus = match self.focus_target_for_input(&window_target).await {
             Ok(focus) => focus,
             Err(message) => {
                 return Json(ActionOutput {
@@ -1555,16 +1557,36 @@ impl ComputerUseLinux {
         if self.should_prefer_kde_clipboard_text_backend() {
             match self.ensure_portal_keyboard_session().await {
                 Ok(Some(session)) => {
+                    let kde_focus = if window_target.has_target() {
+                        match self.focus_target_for_input(&window_target).await {
+                            Ok(focus) => focus,
+                            Err(message) => {
+                                return Json(ActionOutput {
+                                    ok: false,
+                                    implemented: true,
+                                    action: "type_text".to_string(),
+                                    message,
+                                    received,
+                                });
+                            }
+                        }
+                    } else {
+                        focus.clone()
+                    };
+                    let use_terminal_paste =
+                        kde_clipboard_uses_terminal_paste(&window_target, kde_focus.as_ref()).await;
                     let _clipboard_guard = self.kde_clipboard_lock.lock().await;
-                    match run_kde_clipboard_paste_text(&session, &params.text).await {
+                    match run_kde_clipboard_paste_text(&session, &params.text, use_terminal_paste)
+                        .await
+                    {
                         Ok(message) => {
-                            let notes = self.input_landing_notes(focus.as_ref(), true).await;
+                            let notes = self.input_landing_notes(kde_focus.as_ref(), true).await;
                             return Json(with_notes(
                                 successful_action_with_focus(
                                     "type_text",
                                     &message,
                                     received,
-                                    focus,
+                                    kde_focus,
                                 ),
                                 notes,
                             ));
@@ -1578,7 +1600,7 @@ impl ComputerUseLinux {
                                     "type_text",
                                     Err(error.message),
                                     received,
-                                    focus,
+                                    kde_focus,
                                 ));
                             }
                         }
@@ -4625,6 +4647,7 @@ fn ydotool_type_timeout(text: &str) -> Duration {
 }
 
 const EVDEV_KEY_LEFTCTRL: i32 = 29;
+const EVDEV_KEY_LEFTSHIFT: i32 = 42;
 const EVDEV_KEY_V: i32 = 47;
 const KDE_CLIPBOARD_RESTORE_MIN_DELAY_MS: u64 = 1_500;
 const KDE_CLIPBOARD_RESTORE_MAX_DELAY_MS: u64 = 5_000;
@@ -4668,6 +4691,7 @@ impl KdeClipboardPasteError {
 async fn run_kde_clipboard_paste_text(
     session: &PortalKeyboardSession,
     text: &str,
+    use_terminal_paste: bool,
 ) -> std::result::Result<String, KdeClipboardPasteError> {
     let previous = kde_clipboard_contents()
         .await
@@ -4676,9 +4700,13 @@ async fn run_kde_clipboard_paste_text(
         .await
         .map_err(KdeClipboardPasteError::before_text_input)?;
 
-    let paste_result = press_keycode_chord(session, &[EVDEV_KEY_LEFTCTRL], EVDEV_KEY_V)
-        .await
-        .map_err(|error| format!("{error:#}"));
+    let paste_result = press_keycode_chord(
+        session,
+        kde_clipboard_paste_modifiers(use_terminal_paste),
+        EVDEV_KEY_V,
+    )
+    .await
+    .map_err(|error| format!("{error:#}"));
 
     sleep(kde_clipboard_restore_delay(text)).await;
     let restore_result = kde_set_clipboard_contents(&previous).await;
@@ -4692,6 +4720,38 @@ async fn run_kde_clipboard_paste_text(
         (Err(error), Err(restore_error)) => Err(KdeClipboardPasteError::after_portal_input(
             format!("{error}; previous KDE clipboard contents could not be restored: {restore_error}"),
         )),
+    }
+}
+
+async fn kde_clipboard_uses_terminal_paste(
+    target: &WindowTarget,
+    focus: Option<&WindowFocusResult>,
+) -> bool {
+    if let Some(focus) = focus {
+        let window = focus
+            .focused_window
+            .as_ref()
+            .unwrap_or(&focus.requested_window);
+        return kde_clipboard_target_is_terminal(target, Some(window));
+    }
+    if let Ok(Some(current)) = focused_window().await {
+        return kde_clipboard_target_is_terminal(target, Some(&current));
+    }
+    kde_clipboard_target_is_terminal(target, None)
+}
+
+fn kde_clipboard_target_is_terminal(target: &WindowTarget, window: Option<&WindowInfo>) -> bool {
+    match window {
+        Some(window) => uses_terminal_paste_shortcut(window),
+        None => target.has_terminal_target(),
+    }
+}
+
+fn kde_clipboard_paste_modifiers(use_terminal_paste: bool) -> &'static [i32] {
+    if use_terminal_paste {
+        &[EVDEV_KEY_LEFTCTRL, EVDEV_KEY_LEFTSHIFT]
+    } else {
+        &[EVDEV_KEY_LEFTCTRL]
     }
 }
 
@@ -5965,6 +6025,103 @@ mod tests {
             kde_clipboard_restore_delay(&capped_text),
             Duration::from_millis(KDE_CLIPBOARD_RESTORE_MAX_DELAY_MS)
         );
+    }
+
+    #[test]
+    fn kde_clipboard_uses_terminal_paste_shortcut_for_terminals() {
+        assert_eq!(
+            kde_clipboard_paste_modifiers(true),
+            &[EVDEV_KEY_LEFTCTRL, EVDEV_KEY_LEFTSHIFT]
+        );
+    }
+
+    #[test]
+    fn kde_clipboard_keeps_standard_paste_shortcut_for_other_apps() {
+        assert_eq!(kde_clipboard_paste_modifiers(false), &[EVDEV_KEY_LEFTCTRL]);
+    }
+
+    #[test]
+    fn kde_clipboard_routes_explicit_tty_targets_to_terminal_paste() {
+        let target = WindowTarget {
+            tty: Some("/dev/pts/11".to_string()),
+            ..Default::default()
+        };
+
+        assert!(kde_clipboard_target_is_terminal(&target, None));
+    }
+
+    #[test]
+    fn kde_clipboard_prefers_resolved_window_over_stale_terminal_selector() {
+        let target = WindowTarget {
+            tty: Some("/dev/pts/11".to_string()),
+            ..Default::default()
+        };
+        let window = window_info(
+            1,
+            Some("Browser"),
+            Some("firefox"),
+            Some("firefox"),
+            Some(100),
+        );
+
+        assert!(!kde_clipboard_target_is_terminal(&target, Some(&window)));
+    }
+
+    #[tokio::test]
+    async fn kde_clipboard_async_routing_prefers_focus_over_stale_terminal_selector() {
+        let target = WindowTarget {
+            tty: Some("/dev/pts/11".to_string()),
+            ..Default::default()
+        };
+        let window = window_info(
+            1,
+            Some("Browser"),
+            Some("firefox"),
+            Some("firefox"),
+            Some(100),
+        );
+        let focus = WindowFocusResult {
+            requested_window: window.clone(),
+            focused_window: Some(window),
+            exact_window_focused: true,
+            app_focused: true,
+            backend: KWIN_BACKEND.to_string(),
+            note: "test".to_string(),
+        };
+
+        assert!(!kde_clipboard_uses_terminal_paste(&target, Some(&focus)).await);
+    }
+
+    #[test]
+    fn kde_clipboard_routes_konsole_identity_to_terminal_paste() {
+        let window = window_info(
+            1,
+            Some("unflappable-donkey"),
+            Some("org.kde.konsole"),
+            Some("konsole"),
+            Some(100),
+        );
+
+        assert!(kde_clipboard_target_is_terminal(
+            &WindowTarget::default(),
+            Some(&window)
+        ));
+    }
+
+    #[test]
+    fn kde_clipboard_does_not_classify_terminal_words_in_browser_titles() {
+        let window = window_info(
+            1,
+            Some("xterm documentation"),
+            Some("firefox"),
+            Some("firefox"),
+            Some(100),
+        );
+
+        assert!(!kde_clipboard_target_is_terminal(
+            &WindowTarget::default(),
+            Some(&window)
+        ));
     }
 
     #[tokio::test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -216,33 +216,76 @@ fn process_depth(pid: u32, ancestor_pid: u32, by_pid: &HashMap<u32, &ProcessInfo
 }
 
 fn looks_like_terminal_window(window: &WindowInfo) -> bool {
-    let haystack = [
-        window.app_id.as_deref(),
-        window.wm_class.as_deref(),
-        window.title.as_deref(),
-    ]
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>()
-    .join(" ")
-    .to_ascii_lowercase();
-
-    [
-        "ghostty",
-        "gnome-terminal",
-        "org.gnome.terminal",
-        "ptyxis",
-        "org.gnome.ptyxis",
-        "kgx",
-        "konsole",
-        "kitty",
-        "alacritty",
-        "wezterm",
-        "xterm",
-    ]
-    .iter()
-    .any(|needle| haystack.contains(needle))
+    uses_terminal_paste_shortcut(window)
+        || window.title.as_deref().is_some_and(|title| {
+            let title = title.to_ascii_lowercase();
+            TERMINAL_TITLE_HINTS
+                .iter()
+                .any(|needle| title.contains(needle))
+        })
 }
+
+pub(crate) fn uses_terminal_paste_shortcut(window: &WindowInfo) -> bool {
+    window.terminal.is_some()
+        || [window.app_id.as_deref(), window.wm_class.as_deref()]
+            .into_iter()
+            .flatten()
+            .any(terminal_identity_matches)
+}
+
+fn terminal_identity_matches(value: &str) -> bool {
+    let identity = value.trim().to_ascii_lowercase();
+    let identity = identity.strip_suffix(".desktop").unwrap_or(&identity);
+    TERMINAL_IDENTITIES.contains(&identity)
+}
+
+const TERMINAL_IDENTITIES: &[&str] = &[
+    "alacritty",
+    "com.gexperts.tilix",
+    "com.mitchellh.ghostty",
+    "com.system76.cosmicterm",
+    "foot",
+    "gnome-terminal",
+    "gnome-terminal-server",
+    "io.elementary.terminal",
+    "kitty",
+    "kgx",
+    "konsole",
+    "lxterminal",
+    "mate-terminal",
+    "org.codeberg.dnkl.foot",
+    "org.gnome.console",
+    "org.gnome.ptyxis",
+    "org.gnome.terminal",
+    "org.kde.konsole",
+    "org.kde.yakuake",
+    "org.lxqt.qterminal",
+    "org.wezfurlong.wezterm",
+    "ptyxis",
+    "qterminal",
+    "rxvt",
+    "rxvt-unicode",
+    "sakura",
+    "terminator",
+    "tilix",
+    "urxvt",
+    "wezterm",
+    "wezterm-gui",
+    "xfce4-terminal",
+    "xterm",
+    "yakuake",
+];
+
+const TERMINAL_TITLE_HINTS: &[&str] = &[
+    "alacritty",
+    "ghostty",
+    "gnome terminal",
+    "konsole",
+    "kitty",
+    "ptyxis",
+    "wezterm",
+    "xterm",
+];
 
 fn read_process_table() -> Vec<ProcessInfo> {
     let Ok(entries) = fs::read_dir("/proc") else {
@@ -417,6 +460,59 @@ mod tests {
         enrich_terminal_windows_with_processes(&mut windows, &processes);
 
         assert!(windows.iter().all(|window| window.terminal.is_none()));
+    }
+
+    #[test]
+    fn terminal_paste_identity_matching_is_exact() {
+        let mut window = terminal_window(11, 100);
+        window.app_id = Some("com.example.footnotes".to_string());
+        window.wm_class = Some("kitty-helper".to_string());
+
+        assert!(!uses_terminal_paste_shortcut(&window));
+    }
+
+    #[test]
+    fn terminal_paste_recognizes_common_terminal_identities() {
+        for identity in [
+            "org.kde.konsole",
+            "org.gnome.Terminal",
+            "org.gnome.Ptyxis",
+            "kgx",
+            "xfce4-terminal",
+            "org.codeberg.dnkl.foot.desktop",
+        ] {
+            let mut window = terminal_window(11, 100);
+            window.app_id = Some(identity.to_string());
+            window.wm_class = None;
+            assert!(
+                uses_terminal_paste_shortcut(&window),
+                "did not recognize {identity}"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_paste_accepts_wm_class_or_enriched_pty_metadata() {
+        let mut window = terminal_window(11, 100);
+        window.app_id = None;
+        window.wm_class = Some("qterminal".to_string());
+        assert!(uses_terminal_paste_shortcut(&window));
+
+        window.wm_class = None;
+        window.terminal = Some(TerminalWindowContext {
+            tty: "/dev/pts/11".to_string(),
+            root_process: TerminalProcess {
+                pid: 200,
+                command_name: "bash".to_string(),
+                command_line: "bash".to_string(),
+                cwd: Some("/home/user".to_string()),
+            },
+            active_process: None,
+            process_count: 1,
+            confidence: "high".to_string(),
+            match_reason: "test".to_string(),
+        });
+        assert!(uses_terminal_paste_shortcut(&window));
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -269,6 +269,7 @@ const TERMINAL_IDENTITIES: &[&str] = &[
     "terminator",
     "tilix",
     "urxvt",
+    "uxterm",
     "wezterm",
     "wezterm-gui",
     "xfce4-terminal",
@@ -478,6 +479,7 @@ mod tests {
             "org.gnome.Terminal",
             "org.gnome.Ptyxis",
             "kgx",
+            "uxterm",
             "xfce4-terminal",
             "org.codeberg.dnkl.foot.desktop",
         ] {


### PR DESCRIPTION
Transparently, agent/ai generated, but real issue I was having. Feel free to reject as needed!

## Summary

- send `Ctrl+Shift+V` when KDE clipboard text input targets a terminal
- preserve standard `Ctrl+V` behavior for non-terminal applications
- identify terminals through enriched PTY metadata or exact app ID/WM class matches
- re-focus and verify explicit targets after portal setup before pasting

## Problem

On KDE Plasma Wayland, `type_text` places text on the Klipper clipboard and synthesizes `Ctrl+V`.

Terminal applications such as Konsole use `Ctrl+Shift+V` for paste. Inside Readline, `Ctrl+V` instead activates quoted-insert mode. The requested text is not pasted, and the following Enter key is inserted literally and displayed as `^M`.

## Implementation

Terminal paste routing prefers the verified focused window, then the currently focused window, and only falls back to explicit terminal selectors when window information is unavailable.

Terminal identities use exact, case-insensitive app ID and WM class matches. Window titles are not used for shortcut routing, avoiding false positives such as browsers displaying terminal documentation.

Explicit targets are re-focused after portal-session creation so a permission dialog cannot leave input targeting stale.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked kde_clipboard_`
- `cargo test --locked terminal_paste`
- `python3 scripts/mcp_safety_check.py`
- `bash scripts/install_sh_test.sh`
- independent code review: no findings

The full suite has five environment-sensitive `/tmp`/KWin fixture failures in this service environment. The same five failures reproduce on an unchanged `main`; all additional tests pass.